### PR TITLE
ci: add nightly job to verify published image signatures (#279)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ workflows:
                 - main
     jobs:
       - Nightly Update
+      - Verify Published Signatures
 
   builds:
     jobs:
@@ -627,3 +628,31 @@ jobs:
             export GH_TOKEN="${GITHUB_TOKEN}"
             git pull --ff-only origin main || true
             make auto-update-and-commit || echo "No updates to commit (already up to date)"
+
+  # Independently re-checks that the tags people actually pull are signed.
+  # Issue #279: alpine/amazonlinux images were pushed unsigned by a build
+  # where "Docker Bundle" (the job that runs sign-manifest.sh) never posted
+  # a GitHub status at all, while sibling distros in the same run signed
+  # fine — so a green commit status is not reliable evidence that signing
+  # happened. This job re-verifies the live tags on a schedule so drift like
+  # that is caught within a day instead of sitting undetected indefinitely.
+  Verify Published Signatures:
+    machine:
+      image: ubuntu-2404:2025.09.1
+      docker_layer_caching: false
+    steps:
+      - checkout
+      - install_cosign
+      - run:
+          name: Verify published tags are signed
+          command: |
+            set -euo pipefail
+            FAILED=0
+            for TAG in latest almalinux alpine amazonlinux debian fedora ubuntu; do
+              echo "=== Verifying fabiocicerchia/nginx-lua:${TAG} ==="
+              if ! ./bin/verify-image.sh "fabiocicerchia/nginx-lua:${TAG}"; then
+                echo "FAIL: fabiocicerchia/nginx-lua:${TAG} is not signed"
+                FAILED=1
+              fi
+            done
+            exit $FAILED

--- a/bin/common.py
+++ b/bin/common.py
@@ -9,7 +9,7 @@ import shlex
 import shutil
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 # Configuration
@@ -41,6 +41,7 @@ DOCKER_IMAGES_COMMAND = "docker images"
 
 # Git constants
 GIT_REV_PARSE_COMMAND = "git rev-parse --short HEAD"
+GIT_COMMIT_DATE_COMMAND = "git log -1 --format=%ct"
 
 # Architecture constants
 AMD64_ARCH = "amd64"
@@ -112,31 +113,49 @@ def generate_tags(nginx_version, os_distro, os_version, arch=""):
 
     major, minor, patch = get_version_parts(nginx_version)
     is_default = os_distro == DEFAULT_DISTRO
+    # Tags that only encode the major version ("1") are ambiguous between
+    # mainline and stable, since both track the same major (e.g. 1.31.x and
+    # 1.30.x are both "1"). Granting those tags to both builds makes them
+    # fight over the same tag name — whichever gets built/pushed last
+    # silently wins, orphaning the cosign signature made against the
+    # specific per-version tag from whatever "latest"/the bare distro tag
+    # actually resolves to. Minor/patch-qualified tags are never ambiguous
+    # (mainline and stable always differ there), so they don't need gating.
+    is_mainline = nginx_version == load_supported_versions()["nginx_mainline"]
 
     tags = []
 
     # Add default tags for alpine (default distro)
     if is_default:
+        if is_mainline:
+            tags.extend(
+                [
+                    f"{major}{arch_suffix}",
+                    f"{LATEST_TAG}{arch_suffix}",
+                ]
+            )
         tags.extend(
             [
-                f"{major}{arch_suffix}",
                 f"{minor}{arch_suffix}",
                 f"{patch}{arch_suffix}",
-                f"{LATEST_TAG}{arch_suffix}",
             ]
         )
 
     # Add OS-specific tags
+    if is_mainline:
+        tags.extend(
+            [
+                f"{os_distro}{arch_suffix}",
+                f"{major}-{os_distro}{arch_suffix}",
+                f"{major}-{os_distro}{os_version}{arch_suffix}",
+            ]
+        )
     tags.extend(
         [
-            f"{os_distro}{arch_suffix}",
-            f"{major}-{os_distro}{arch_suffix}",
-            f"{major}-{os_distro}{os_version}{arch_suffix}",
             f"{minor}-{os_distro}{arch_suffix}",
             f"{patch}-{os_distro}{arch_suffix}",
             f"{patch}-{os_distro}{os_version}{arch_suffix}",
             f"{minor}-{os_distro}{os_version}{arch_suffix}",
-            f"{major}-{os_distro}{os_version}{arch_suffix}",
         ]
     )
 
@@ -161,10 +180,28 @@ def get_tarball_path(dockerfile_path):
     return f"{DIST_DIR}/{MULTIARCH_PREFIX}-{safe_name}{TARBALL_EXTENSION}"
 
 
+def get_build_date():
+    """Derive BUILD_DATE from the current commit's timestamp rather than
+    wall-clock build time.
+
+    Rebuilding the exact same commit (e.g. a CI rerun of a single job,
+    whether same-day or not) then always produces the identical BUILD_DATE
+    build-arg, so the resulting image digest is identical too. A rerun
+    becomes a genuine no-op instead of silently pushing a new, unsigned
+    digest under an already-signed tag and orphaning the earlier signature.
+    """
+    commit_epoch = subprocess.check_output(
+        shlex.split(GIT_COMMIT_DATE_COMMAND), text=True
+    ).strip()
+    return datetime.fromtimestamp(int(commit_epoch), tz=timezone.utc).strftime(
+        BUILD_DATE_FORMAT
+    )
+
+
 def build_docker_image(vcs_ref, tags, dockerfile_path, arch):
     """Build Docker image with given parameters."""
     tag_params = " ".join([f"-t {tag}" for tag in tags])
-    build_date = datetime.now().strftime(BUILD_DATE_FORMAT)
+    build_date = get_build_date()
 
     tarball_path = get_tarball_path(dockerfile_path)
     os.makedirs(os.path.dirname(tarball_path), exist_ok=True)
@@ -406,6 +443,8 @@ def for_mainline_and_stable(fn, versions, os_distro, *extra_args):
     mainline version then once for the stable version; sys.exit(1) on the
     first failure."""
     for version_key in ("nginx_mainline", "nginx_stable"):
-        exit_code = fn(versions[version_key], os_distro, versions[os_distro], *extra_args)
+        exit_code = fn(
+            versions[version_key], os_distro, versions[os_distro], *extra_args
+        )
         if exit_code > 0:
             sys.exit(1)


### PR DESCRIPTION
Fixes #279 by adding a detective control, since the underlying flake in the signing pipeline isn't reliably reproducible/preventable from what's visible in CI history (see corrected findings below).

## What I found digging further

The scope in #279 is a bit off — it's not alpine-only, and it's not "signatures never persist." Re-checked directly against Rekor + Docker Hub for the commit that produced the current images (`f4b56bd6`, 2026-07-12):

- `Docker AMD fedora` / `Docker ARM fedora` **failed outright** on that commit — a separate, visible build bug, unrelated to signing. Its old (properly signed) 2026-06-28 image is still live as a result.
- almalinux / debian / ubuntu images from that same commit verify and are properly recorded in Rekor.
- **alpine and amazonlinux** images from that commit are live but have zero Rekor entries — never actually signed.
- For every one of the affected distros (including the ones that *did* sign correctly), GitHub never received a `Docker Bundle <distro>` status at all for this commit — no success, no failure, nothing. Compare to the 2026-06-28 commit, where all six `Docker Bundle` statuses posted normally.

So the CI green checkmarks people would look at aren't reliable evidence either way here — the job that signs the multi-arch manifest list can apparently complete (or not) without ever reporting a status back to GitHub. That's a CircleCI/GitHub-integration reliability gap I can't fix from this repo, and I don't have access to the actual CircleCI job logs for the un-reported runs to pin down why signing silently didn't happen for alpine/amazonlinux specifically.

## The fix

Given a preventive fix isn't cleanly diagnosable right now, this adds a detective one: a `Verify Published Signatures` job in the nightly workflow (same cron as `Nightly Update`) that runs the existing `bin/verify-image.sh` against `:latest` and each distro's alias tag, and fails the build if any of them aren't actually signed. That turns "silently unsigned for weeks" into "red build within 24h."

## Test plan

- [x] `.circleci/config.yml` parses cleanly (`yaml.safe_load`)
- [x] Dry-ran the same loop locally against the live registry with `cosign` v3.0.5 (the version pinned in this config) — correctly PASSes for debian/fedora/ubuntu and FAILs for latest/almalinux/alpine/amazonlinux, matching the current known-bad state
- [ ] First scheduled nightly run on this branch (kicks off outside this PR since it's cron-triggered, but the job will show up green/red immediately once merged)