### PR TITLE
Use commit timestamp for BUILD_DATE instead of wall-clock time

### DIFF
--- a/bin/common.py
+++ b/bin/common.py
@@ -8,7 +8,7 @@ import re
 import shlex
 import shutil
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 # Configuration
@@ -41,6 +41,7 @@ DOCKER_IMAGES_COMMAND = "docker images"
 
 # Git constants
 GIT_REV_PARSE_COMMAND = "git rev-parse --short HEAD"
+GIT_COMMIT_DATE_COMMAND = "git log -1 --format=%ct"
 
 # Architecture constants
 AMD64_ARCH = "amd64"
@@ -173,10 +174,26 @@ def get_tarball_path(dockerfile_path):
     return f"{DIST_DIR}/{MULTIARCH_PREFIX}-{safe_name}{TARBALL_EXTENSION}"
 
 
+def get_build_date():
+    """Derive BUILD_DATE from the current commit's timestamp rather than
+    wall-clock build time.
+
+    Rebuilding the exact same commit (e.g. a CI rerun of a single job,
+    whether same-day or not) then always produces the identical BUILD_DATE
+    build-arg, so the resulting image digest is identical too. A rerun
+    becomes a genuine no-op instead of silently pushing a new, unsigned
+    digest under an already-signed tag and orphaning the earlier signature.
+    """
+    commit_epoch = subprocess.check_output(
+        shlex.split(GIT_COMMIT_DATE_COMMAND), text=True
+    ).strip()
+    return datetime.fromtimestamp(int(commit_epoch), tz=timezone.utc).strftime(BUILD_DATE_FORMAT)
+
+
 def build_docker_image(vcs_ref, tags, dockerfile_path, arch):
     """Build Docker image with given parameters."""
     tag_params = " ".join([f"-t {tag}" for tag in tags])
-    build_date = datetime.now().strftime(BUILD_DATE_FORMAT)
+    build_date = get_build_date()
 
     tarball_path = get_tarball_path(dockerfile_path)
     os.makedirs(os.path.dirname(tarball_path), exist_ok=True)

--- a/bin/common.py
+++ b/bin/common.py
@@ -114,28 +114,42 @@ def generate_tags(nginx_version, os_distro, os_version, arch=""):
 
     major, minor, patch = get_version_parts(nginx_version)
     is_default = os_distro == DEFAULT_DISTRO
+    # Tags that only encode the major version ("1") are ambiguous between
+    # mainline and stable, since both track the same major (e.g. 1.31.x and
+    # 1.30.x are both "1"). Granting those tags to both builds makes them
+    # fight over the same tag name — whichever gets built/pushed last
+    # silently wins, orphaning the cosign signature made against the
+    # specific per-version tag from whatever "latest"/the bare distro tag
+    # actually resolves to. Minor/patch-qualified tags are never ambiguous
+    # (mainline and stable always differ there), so they don't need gating.
+    is_mainline = nginx_version == load_supported_versions()["nginx_mainline"]
 
     tags = []
 
     # Add default tags for alpine (default distro)
     if is_default:
+        if is_mainline:
+            tags.extend([
+                f"{major}{arch_suffix}",
+                f"{LATEST_TAG}{arch_suffix}"
+            ])
         tags.extend([
-            f"{major}{arch_suffix}",
             f"{minor}{arch_suffix}",
             f"{patch}{arch_suffix}",
-            f"{LATEST_TAG}{arch_suffix}"
         ])
 
     # Add OS-specific tags
+    if is_mainline:
+        tags.extend([
+            f"{os_distro}{arch_suffix}",
+            f"{major}-{os_distro}{arch_suffix}",
+            f"{major}-{os_distro}{os_version}{arch_suffix}",
+        ])
     tags.extend([
-        f"{os_distro}{arch_suffix}",
-        f"{major}-{os_distro}{arch_suffix}",
-        f"{major}-{os_distro}{os_version}{arch_suffix}",
         f"{minor}-{os_distro}{arch_suffix}",
         f"{patch}-{os_distro}{arch_suffix}",
         f"{patch}-{os_distro}{os_version}{arch_suffix}",
         f"{minor}-{os_distro}{os_version}{arch_suffix}",
-        f"{major}-{os_distro}{os_version}{arch_suffix}"
     ])
 
     # Add repository prefix and remove duplicates


### PR DESCRIPTION
## Summary
This PR improves Docker image reproducibility by deriving the `BUILD_DATE` build argument from the current commit's timestamp rather than the wall-clock build time. Additionally, it gates major-version-only tags to mainline builds to prevent tag conflicts between mainline and stable releases.

## Key Changes
- **Reproducible builds**: Added `get_build_date()` function that extracts the commit timestamp using `git log` and converts it to the `BUILD_DATE` format. This ensures that rebuilding the same commit always produces an identical image digest, making CI reruns true no-ops instead of silently pushing new unsigned digests.
- **Tag gating for mainline**: Modified `generate_tags()` to only apply major-version tags (e.g., "1") and the "latest" tag to mainline builds. This prevents ambiguity and tag conflicts, since both mainline and stable releases share the same major version number but differ in minor/patch versions.
- **Import addition**: Added `timezone` to the datetime imports to support UTC timestamp conversion.

## Implementation Details
- The `get_build_date()` function executes `git log -1 --format=%ct` to retrieve the commit's Unix timestamp, then converts it to UTC datetime and formats it according to `BUILD_DATE_FORMAT`.
- Tag gating checks if the current nginx version matches the mainline version from `load_supported_versions()`, and conditionally includes major-version and latest tags only for mainline builds.
- The change maintains backward compatibility for minor and patch-qualified tags, which remain unaffected and are generated for all builds.

https://claude.ai/code/session_01Pmc8mL8LL8bv8VergrXUKe