### PR TITLE
ci: authenticate to Docker Hub before the base-image pulls, not after

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,6 +192,23 @@ commands:
             echo "libseccomp2 version: $(dpkg -s libseccomp2 | grep '^Version:')"
 
       - run:
+          name: Log into registry
+          command: |
+            # Authenticate before the base-image FROM pulls below (in "Build
+            # docker image"), not just before the main-branch push/scan steps.
+            # Anonymous pulls share Docker Hub's per-IP rate limit across every
+            # CircleCI tenant on the same runner IP; authenticating up front
+            # puts these pulls against our own account's quota instead.
+            # DOCKER_HUB_TOKEN is unset on fork PR builds (CircleCI doesn't
+            # expose secrets to those) — fall back to anonymous rather than
+            # failing the job.
+            if [ -n "${DOCKER_HUB_TOKEN:-}" ]; then
+              echo "${DOCKER_HUB_TOKEN}" | docker login --username "${DOCKER_HUB_USER}" --password-stdin
+            else
+              echo "No DOCKER_HUB_TOKEN available (e.g. fork PR) — pulling anonymously"
+            fi
+
+      - run:
           name: Install Python Dependencies
           command: pip3 install -r bin/requirements.txt
 
@@ -285,10 +302,6 @@ commands:
             and:
               - equal: [main, << pipeline.git.branch >>]
           steps:
-            - run:
-                name: Log into registry
-                command: |
-                  echo "${DOCKER_HUB_TOKEN}" | docker login --username "${DOCKER_HUB_USER}" --password-stdin
             - run:
                 name: Scan for vulnerabilities (build gate)
                 command: |


### PR DESCRIPTION
## Summary

- `docker login` only ran inside the main-branch-only `when` gate, *after* the "Build docker image" step had already run. Since the `Docker AMD`/`Docker ARM` jobs have no branch filter, every branch and PR triggers the full 6-distro × 2-arch build matrix, and each `docker build`'s `FROM` pull happened anonymously — sharing Docker Hub's per-IP pull rate limit with every other CircleCI tenant whose builds land on the same runner IP, instead of using this project's own account quota.
- Moved the login to run right after `check docker`, before any image is built. Falls back to anonymous pulls only when `DOCKER_HUB_TOKEN` isn't available (e.g. a fork PR, where CircleCI doesn't expose secrets), rather than failing the job.
- Removed the now-redundant second login that lived inside the main-branch-only gate.

## Test plan

- [ ] `.circleci/config.yml` parses as valid YAML (verified locally with `python3 -c "import yaml; yaml.safe_load(open('.circleci/config.yml'))"`)
- [ ] CircleCI `Docker AMD`/`Docker ARM` jobs run green on a non-main branch, confirming the early login step succeeds and the build still proceeds
- [ ] Confirm `docker login` output appears before "Build docker image" in the job logs


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pmc8mL8LL8bv8VergrXUKe)_