### PR TITLE
fix: openresty patch fallback picks nearest lower version instead of latest

### DIFF
--- a/nginx/1.30.3/almalinux/10.2-20260602/tpl/Makefile
+++ b/nginx/1.30.3/almalinux/10.2-20260602/tpl/Makefile
@@ -57,10 +57,17 @@ SKIPPED_PATCHES=""
 openresty-patches:
 	mkdir -p /nginx-${VER_NGINX}/patches
 	git clone https://github.com/openresty/openresty.git; \
+	# ponytail: openresty only publishes patches for mainline (odd) nginx
+	# releases, so "nearest available version <= VER_NGINX" already resolves
+	# to the previous mainline branch for stable targets - no parity filter needed.
 	PATCH_VER=${VER_NGINX}; \
 	if [ "$$(ls -1 openresty/patches/nginx/${VER_NGINX}/nginx-${VER_NGINX}-*.patch 2>/dev/null)" = "" ]; then \
-		PATCH_VER=$$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {} | sort -V | tail -1); \
-		echo "No patches for ${VER_NGINX}, falling back to latest available: $${PATCH_VER}"; \
+		PATCH_VER=$$(printf '%s\n' $$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {}) ${VER_NGINX} | sort -V | grep -B1 -x "${VER_NGINX}" | head -1); \
+		if [ -z "$$PATCH_VER" ] || [ "$$PATCH_VER" = "${VER_NGINX}" ]; then \
+			echo "FATAL: no openresty nginx patch version <= ${VER_NGINX} available" >&2; \
+			exit 1; \
+		fi; \
+		echo "No patches for ${VER_NGINX}, falling back to most recent lower version: $${PATCH_VER}"; \
 	fi; \
 	for patch_file in openresty/patches/nginx/$${PATCH_VER}/nginx-$${PATCH_VER}-*.patch; do \
 		echo "copying openresty patch $${patch_file}"; \

--- a/nginx/1.30.3/alpine/3.24.1/tpl/Makefile
+++ b/nginx/1.30.3/alpine/3.24.1/tpl/Makefile
@@ -57,10 +57,17 @@ SKIPPED_PATCHES=""
 openresty-patches:
 	mkdir -p /nginx-${VER_NGINX}/patches
 	git clone https://github.com/openresty/openresty.git; \
+	# ponytail: openresty only publishes patches for mainline (odd) nginx
+	# releases, so "nearest available version <= VER_NGINX" already resolves
+	# to the previous mainline branch for stable targets - no parity filter needed.
 	PATCH_VER=${VER_NGINX}; \
 	if [ "$$(ls -1 openresty/patches/nginx/${VER_NGINX}/nginx-${VER_NGINX}-*.patch 2>/dev/null)" = "" ]; then \
-		PATCH_VER=$$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {} | sort -V | tail -1); \
-		echo "No patches for ${VER_NGINX}, falling back to latest available: $${PATCH_VER}"; \
+		PATCH_VER=$$(printf '%s\n' $$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {}) ${VER_NGINX} | sort -V | grep -B1 -x "${VER_NGINX}" | head -1); \
+		if [ -z "$$PATCH_VER" ] || [ "$$PATCH_VER" = "${VER_NGINX}" ]; then \
+			echo "FATAL: no openresty nginx patch version <= ${VER_NGINX} available" >&2; \
+			exit 1; \
+		fi; \
+		echo "No patches for ${VER_NGINX}, falling back to most recent lower version: $${PATCH_VER}"; \
 	fi; \
 	for patch_file in openresty/patches/nginx/$${PATCH_VER}/nginx-$${PATCH_VER}-*.patch; do \
 		echo "copying openresty patch $${patch_file}"; \

--- a/nginx/1.30.3/amazonlinux/2023.12.20260706.1/tpl/Makefile
+++ b/nginx/1.30.3/amazonlinux/2023.12.20260706.1/tpl/Makefile
@@ -57,10 +57,17 @@ SKIPPED_PATCHES=""
 openresty-patches:
 	mkdir -p /nginx-${VER_NGINX}/patches
 	git clone https://github.com/openresty/openresty.git; \
+	# ponytail: openresty only publishes patches for mainline (odd) nginx
+	# releases, so "nearest available version <= VER_NGINX" already resolves
+	# to the previous mainline branch for stable targets - no parity filter needed.
 	PATCH_VER=${VER_NGINX}; \
 	if [ "$$(ls -1 openresty/patches/nginx/${VER_NGINX}/nginx-${VER_NGINX}-*.patch 2>/dev/null)" = "" ]; then \
-		PATCH_VER=$$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {} | sort -V | tail -1); \
-		echo "No patches for ${VER_NGINX}, falling back to latest available: $${PATCH_VER}"; \
+		PATCH_VER=$$(printf '%s\n' $$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {}) ${VER_NGINX} | sort -V | grep -B1 -x "${VER_NGINX}" | head -1); \
+		if [ -z "$$PATCH_VER" ] || [ "$$PATCH_VER" = "${VER_NGINX}" ]; then \
+			echo "FATAL: no openresty nginx patch version <= ${VER_NGINX} available" >&2; \
+			exit 1; \
+		fi; \
+		echo "No patches for ${VER_NGINX}, falling back to most recent lower version: $${PATCH_VER}"; \
 	fi; \
 	for patch_file in openresty/patches/nginx/$${PATCH_VER}/nginx-$${PATCH_VER}-*.patch; do \
 		echo "copying openresty patch $${patch_file}"; \

--- a/nginx/1.30.3/debian/13.5/tpl/Makefile
+++ b/nginx/1.30.3/debian/13.5/tpl/Makefile
@@ -57,10 +57,17 @@ SKIPPED_PATCHES=""
 openresty-patches:
 	mkdir -p /nginx-${VER_NGINX}/patches
 	git clone https://github.com/openresty/openresty.git; \
+	# ponytail: openresty only publishes patches for mainline (odd) nginx
+	# releases, so "nearest available version <= VER_NGINX" already resolves
+	# to the previous mainline branch for stable targets - no parity filter needed.
 	PATCH_VER=${VER_NGINX}; \
 	if [ "$$(ls -1 openresty/patches/nginx/${VER_NGINX}/nginx-${VER_NGINX}-*.patch 2>/dev/null)" = "" ]; then \
-		PATCH_VER=$$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {} | sort -V | tail -1); \
-		echo "No patches for ${VER_NGINX}, falling back to latest available: $${PATCH_VER}"; \
+		PATCH_VER=$$(printf '%s\n' $$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {}) ${VER_NGINX} | sort -V | grep -B1 -x "${VER_NGINX}" | head -1); \
+		if [ -z "$$PATCH_VER" ] || [ "$$PATCH_VER" = "${VER_NGINX}" ]; then \
+			echo "FATAL: no openresty nginx patch version <= ${VER_NGINX} available" >&2; \
+			exit 1; \
+		fi; \
+		echo "No patches for ${VER_NGINX}, falling back to most recent lower version: $${PATCH_VER}"; \
 	fi; \
 	for patch_file in openresty/patches/nginx/$${PATCH_VER}/nginx-$${PATCH_VER}-*.patch; do \
 		echo "copying openresty patch $${patch_file}"; \

--- a/nginx/1.30.3/fedora/44/tpl/Makefile
+++ b/nginx/1.30.3/fedora/44/tpl/Makefile
@@ -57,10 +57,17 @@ SKIPPED_PATCHES=""
 openresty-patches:
 	mkdir -p /nginx-${VER_NGINX}/patches
 	git clone https://github.com/openresty/openresty.git; \
+	# ponytail: openresty only publishes patches for mainline (odd) nginx
+	# releases, so "nearest available version <= VER_NGINX" already resolves
+	# to the previous mainline branch for stable targets - no parity filter needed.
 	PATCH_VER=${VER_NGINX}; \
 	if [ "$$(ls -1 openresty/patches/nginx/${VER_NGINX}/nginx-${VER_NGINX}-*.patch 2>/dev/null)" = "" ]; then \
-		PATCH_VER=$$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {} | sort -V | tail -1); \
-		echo "No patches for ${VER_NGINX}, falling back to latest available: $${PATCH_VER}"; \
+		PATCH_VER=$$(printf '%s\n' $$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {}) ${VER_NGINX} | sort -V | grep -B1 -x "${VER_NGINX}" | head -1); \
+		if [ -z "$$PATCH_VER" ] || [ "$$PATCH_VER" = "${VER_NGINX}" ]; then \
+			echo "FATAL: no openresty nginx patch version <= ${VER_NGINX} available" >&2; \
+			exit 1; \
+		fi; \
+		echo "No patches for ${VER_NGINX}, falling back to most recent lower version: $${PATCH_VER}"; \
 	fi; \
 	for patch_file in openresty/patches/nginx/$${PATCH_VER}/nginx-$${PATCH_VER}-*.patch; do \
 		echo "copying openresty patch $${patch_file}"; \

--- a/nginx/1.30.3/ubuntu/26.04/tpl/Makefile
+++ b/nginx/1.30.3/ubuntu/26.04/tpl/Makefile
@@ -57,10 +57,17 @@ SKIPPED_PATCHES=""
 openresty-patches:
 	mkdir -p /nginx-${VER_NGINX}/patches
 	git clone https://github.com/openresty/openresty.git; \
+	# ponytail: openresty only publishes patches for mainline (odd) nginx
+	# releases, so "nearest available version <= VER_NGINX" already resolves
+	# to the previous mainline branch for stable targets - no parity filter needed.
 	PATCH_VER=${VER_NGINX}; \
 	if [ "$$(ls -1 openresty/patches/nginx/${VER_NGINX}/nginx-${VER_NGINX}-*.patch 2>/dev/null)" = "" ]; then \
-		PATCH_VER=$$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {} | sort -V | tail -1); \
-		echo "No patches for ${VER_NGINX}, falling back to latest available: $${PATCH_VER}"; \
+		PATCH_VER=$$(printf '%s\n' $$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {}) ${VER_NGINX} | sort -V | grep -B1 -x "${VER_NGINX}" | head -1); \
+		if [ -z "$$PATCH_VER" ] || [ "$$PATCH_VER" = "${VER_NGINX}" ]; then \
+			echo "FATAL: no openresty nginx patch version <= ${VER_NGINX} available" >&2; \
+			exit 1; \
+		fi; \
+		echo "No patches for ${VER_NGINX}, falling back to most recent lower version: $${PATCH_VER}"; \
 	fi; \
 	for patch_file in openresty/patches/nginx/$${PATCH_VER}/nginx-$${PATCH_VER}-*.patch; do \
 		echo "copying openresty patch $${patch_file}"; \

--- a/nginx/1.31.2/almalinux/10.2-20260602/tpl/Makefile
+++ b/nginx/1.31.2/almalinux/10.2-20260602/tpl/Makefile
@@ -57,10 +57,17 @@ SKIPPED_PATCHES=""
 openresty-patches:
 	mkdir -p /nginx-${VER_NGINX}/patches
 	git clone https://github.com/openresty/openresty.git; \
+	# ponytail: openresty only publishes patches for mainline (odd) nginx
+	# releases, so "nearest available version <= VER_NGINX" already resolves
+	# to the previous mainline branch for stable targets - no parity filter needed.
 	PATCH_VER=${VER_NGINX}; \
 	if [ "$$(ls -1 openresty/patches/nginx/${VER_NGINX}/nginx-${VER_NGINX}-*.patch 2>/dev/null)" = "" ]; then \
-		PATCH_VER=$$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {} | sort -V | tail -1); \
-		echo "No patches for ${VER_NGINX}, falling back to latest available: $${PATCH_VER}"; \
+		PATCH_VER=$$(printf '%s\n' $$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {}) ${VER_NGINX} | sort -V | grep -B1 -x "${VER_NGINX}" | head -1); \
+		if [ -z "$$PATCH_VER" ] || [ "$$PATCH_VER" = "${VER_NGINX}" ]; then \
+			echo "FATAL: no openresty nginx patch version <= ${VER_NGINX} available" >&2; \
+			exit 1; \
+		fi; \
+		echo "No patches for ${VER_NGINX}, falling back to most recent lower version: $${PATCH_VER}"; \
 	fi; \
 	for patch_file in openresty/patches/nginx/$${PATCH_VER}/nginx-$${PATCH_VER}-*.patch; do \
 		echo "copying openresty patch $${patch_file}"; \

--- a/nginx/1.31.2/alpine/3.24.1/tpl/Makefile
+++ b/nginx/1.31.2/alpine/3.24.1/tpl/Makefile
@@ -57,10 +57,17 @@ SKIPPED_PATCHES=""
 openresty-patches:
 	mkdir -p /nginx-${VER_NGINX}/patches
 	git clone https://github.com/openresty/openresty.git; \
+	# ponytail: openresty only publishes patches for mainline (odd) nginx
+	# releases, so "nearest available version <= VER_NGINX" already resolves
+	# to the previous mainline branch for stable targets - no parity filter needed.
 	PATCH_VER=${VER_NGINX}; \
 	if [ "$$(ls -1 openresty/patches/nginx/${VER_NGINX}/nginx-${VER_NGINX}-*.patch 2>/dev/null)" = "" ]; then \
-		PATCH_VER=$$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {} | sort -V | tail -1); \
-		echo "No patches for ${VER_NGINX}, falling back to latest available: $${PATCH_VER}"; \
+		PATCH_VER=$$(printf '%s\n' $$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {}) ${VER_NGINX} | sort -V | grep -B1 -x "${VER_NGINX}" | head -1); \
+		if [ -z "$$PATCH_VER" ] || [ "$$PATCH_VER" = "${VER_NGINX}" ]; then \
+			echo "FATAL: no openresty nginx patch version <= ${VER_NGINX} available" >&2; \
+			exit 1; \
+		fi; \
+		echo "No patches for ${VER_NGINX}, falling back to most recent lower version: $${PATCH_VER}"; \
 	fi; \
 	for patch_file in openresty/patches/nginx/$${PATCH_VER}/nginx-$${PATCH_VER}-*.patch; do \
 		echo "copying openresty patch $${patch_file}"; \

--- a/nginx/1.31.2/amazonlinux/2023.12.20260706.1/tpl/Makefile
+++ b/nginx/1.31.2/amazonlinux/2023.12.20260706.1/tpl/Makefile
@@ -57,10 +57,17 @@ SKIPPED_PATCHES=""
 openresty-patches:
 	mkdir -p /nginx-${VER_NGINX}/patches
 	git clone https://github.com/openresty/openresty.git; \
+	# ponytail: openresty only publishes patches for mainline (odd) nginx
+	# releases, so "nearest available version <= VER_NGINX" already resolves
+	# to the previous mainline branch for stable targets - no parity filter needed.
 	PATCH_VER=${VER_NGINX}; \
 	if [ "$$(ls -1 openresty/patches/nginx/${VER_NGINX}/nginx-${VER_NGINX}-*.patch 2>/dev/null)" = "" ]; then \
-		PATCH_VER=$$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {} | sort -V | tail -1); \
-		echo "No patches for ${VER_NGINX}, falling back to latest available: $${PATCH_VER}"; \
+		PATCH_VER=$$(printf '%s\n' $$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {}) ${VER_NGINX} | sort -V | grep -B1 -x "${VER_NGINX}" | head -1); \
+		if [ -z "$$PATCH_VER" ] || [ "$$PATCH_VER" = "${VER_NGINX}" ]; then \
+			echo "FATAL: no openresty nginx patch version <= ${VER_NGINX} available" >&2; \
+			exit 1; \
+		fi; \
+		echo "No patches for ${VER_NGINX}, falling back to most recent lower version: $${PATCH_VER}"; \
 	fi; \
 	for patch_file in openresty/patches/nginx/$${PATCH_VER}/nginx-$${PATCH_VER}-*.patch; do \
 		echo "copying openresty patch $${patch_file}"; \

--- a/nginx/1.31.2/debian/13.5/tpl/Makefile
+++ b/nginx/1.31.2/debian/13.5/tpl/Makefile
@@ -57,10 +57,17 @@ SKIPPED_PATCHES=""
 openresty-patches:
 	mkdir -p /nginx-${VER_NGINX}/patches
 	git clone https://github.com/openresty/openresty.git; \
+	# ponytail: openresty only publishes patches for mainline (odd) nginx
+	# releases, so "nearest available version <= VER_NGINX" already resolves
+	# to the previous mainline branch for stable targets - no parity filter needed.
 	PATCH_VER=${VER_NGINX}; \
 	if [ "$$(ls -1 openresty/patches/nginx/${VER_NGINX}/nginx-${VER_NGINX}-*.patch 2>/dev/null)" = "" ]; then \
-		PATCH_VER=$$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {} | sort -V | tail -1); \
-		echo "No patches for ${VER_NGINX}, falling back to latest available: $${PATCH_VER}"; \
+		PATCH_VER=$$(printf '%s\n' $$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {}) ${VER_NGINX} | sort -V | grep -B1 -x "${VER_NGINX}" | head -1); \
+		if [ -z "$$PATCH_VER" ] || [ "$$PATCH_VER" = "${VER_NGINX}" ]; then \
+			echo "FATAL: no openresty nginx patch version <= ${VER_NGINX} available" >&2; \
+			exit 1; \
+		fi; \
+		echo "No patches for ${VER_NGINX}, falling back to most recent lower version: $${PATCH_VER}"; \
 	fi; \
 	for patch_file in openresty/patches/nginx/$${PATCH_VER}/nginx-$${PATCH_VER}-*.patch; do \
 		echo "copying openresty patch $${patch_file}"; \

--- a/nginx/1.31.2/fedora/44/tpl/Makefile
+++ b/nginx/1.31.2/fedora/44/tpl/Makefile
@@ -57,10 +57,17 @@ SKIPPED_PATCHES=""
 openresty-patches:
 	mkdir -p /nginx-${VER_NGINX}/patches
 	git clone https://github.com/openresty/openresty.git; \
+	# ponytail: openresty only publishes patches for mainline (odd) nginx
+	# releases, so "nearest available version <= VER_NGINX" already resolves
+	# to the previous mainline branch for stable targets - no parity filter needed.
 	PATCH_VER=${VER_NGINX}; \
 	if [ "$$(ls -1 openresty/patches/nginx/${VER_NGINX}/nginx-${VER_NGINX}-*.patch 2>/dev/null)" = "" ]; then \
-		PATCH_VER=$$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {} | sort -V | tail -1); \
-		echo "No patches for ${VER_NGINX}, falling back to latest available: $${PATCH_VER}"; \
+		PATCH_VER=$$(printf '%s\n' $$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {}) ${VER_NGINX} | sort -V | grep -B1 -x "${VER_NGINX}" | head -1); \
+		if [ -z "$$PATCH_VER" ] || [ "$$PATCH_VER" = "${VER_NGINX}" ]; then \
+			echo "FATAL: no openresty nginx patch version <= ${VER_NGINX} available" >&2; \
+			exit 1; \
+		fi; \
+		echo "No patches for ${VER_NGINX}, falling back to most recent lower version: $${PATCH_VER}"; \
 	fi; \
 	for patch_file in openresty/patches/nginx/$${PATCH_VER}/nginx-$${PATCH_VER}-*.patch; do \
 		echo "copying openresty patch $${patch_file}"; \

--- a/nginx/1.31.2/ubuntu/26.04/tpl/Makefile
+++ b/nginx/1.31.2/ubuntu/26.04/tpl/Makefile
@@ -57,10 +57,17 @@ SKIPPED_PATCHES=""
 openresty-patches:
 	mkdir -p /nginx-${VER_NGINX}/patches
 	git clone https://github.com/openresty/openresty.git; \
+	# ponytail: openresty only publishes patches for mainline (odd) nginx
+	# releases, so "nearest available version <= VER_NGINX" already resolves
+	# to the previous mainline branch for stable targets - no parity filter needed.
 	PATCH_VER=${VER_NGINX}; \
 	if [ "$$(ls -1 openresty/patches/nginx/${VER_NGINX}/nginx-${VER_NGINX}-*.patch 2>/dev/null)" = "" ]; then \
-		PATCH_VER=$$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {} | sort -V | tail -1); \
-		echo "No patches for ${VER_NGINX}, falling back to latest available: $${PATCH_VER}"; \
+		PATCH_VER=$$(printf '%s\n' $$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {}) ${VER_NGINX} | sort -V | grep -B1 -x "${VER_NGINX}" | head -1); \
+		if [ -z "$$PATCH_VER" ] || [ "$$PATCH_VER" = "${VER_NGINX}" ]; then \
+			echo "FATAL: no openresty nginx patch version <= ${VER_NGINX} available" >&2; \
+			exit 1; \
+		fi; \
+		echo "No patches for ${VER_NGINX}, falling back to most recent lower version: $${PATCH_VER}"; \
 	fi; \
 	for patch_file in openresty/patches/nginx/$${PATCH_VER}/nginx-$${PATCH_VER}-*.patch; do \
 		echo "copying openresty patch $${patch_file}"; \

--- a/src/Makefile
+++ b/src/Makefile
@@ -57,10 +57,17 @@ SKIPPED_PATCHES=""
 openresty-patches:
 	mkdir -p /nginx-${VER_NGINX}/patches
 	git clone https://github.com/openresty/openresty.git; \
+	# ponytail: openresty only publishes patches for mainline (odd) nginx
+	# releases, so "nearest available version <= VER_NGINX" already resolves
+	# to the previous mainline branch for stable targets - no parity filter needed.
 	PATCH_VER=${VER_NGINX}; \
 	if [ "$$(ls -1 openresty/patches/nginx/${VER_NGINX}/nginx-${VER_NGINX}-*.patch 2>/dev/null)" = "" ]; then \
-		PATCH_VER=$$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {} | sort -V | tail -1); \
-		echo "No patches for ${VER_NGINX}, falling back to latest available: $${PATCH_VER}"; \
+		PATCH_VER=$$(printf '%s\n' $$(ls -1d openresty/patches/nginx/*/ 2>/dev/null | xargs -I{} basename {}) ${VER_NGINX} | sort -V | grep -B1 -x "${VER_NGINX}" | head -1); \
+		if [ -z "$$PATCH_VER" ] || [ "$$PATCH_VER" = "${VER_NGINX}" ]; then \
+			echo "FATAL: no openresty nginx patch version <= ${VER_NGINX} available" >&2; \
+			exit 1; \
+		fi; \
+		echo "No patches for ${VER_NGINX}, falling back to most recent lower version: $${PATCH_VER}"; \
 	fi; \
 	for patch_file in openresty/patches/nginx/$${PATCH_VER}/nginx-$${PATCH_VER}-*.patch; do \
 		echo "copying openresty patch $${patch_file}"; \


### PR DESCRIPTION
## Summary
- All AMD/ARM CI build jobs are failing with a compile error in `ngx_http_log_module.c` (mismatched `ngx_http_log_escape` signature, code outside function braces).
- Root cause: `src/Makefile`'s `openresty-patches` target falls back to the globally **highest** available OpenResty patch set (`sort -V | tail -1`) when no patches exist for the exact pinned `VER_NGINX`. OpenResty has no `patches/nginx/1.30.3/` directory (it only publishes for mainline releases), so this silently resolved to `1.31.3` and force-applied 1.31.3-offset patches onto 1.30.3 source via `patch -p1`. `patch` applies fuzzy/mismatched hunks without erroring, so it silently corrupted `ngx_http_log_module.c`.
- Fix: fall back to the nearest available patch version **<=** `VER_NGINX` instead of the global max, and fail the build loudly if no such version exists (rather than silently reusing an incompatible newer patch set). Same `sort -V` idiom already used in this recipe, no new tooling.
- Regenerated the affected per-version/distro `tpl/Makefile` copies via `bin/generate-dockerfiles.py` (`nginx/**` is generated from `src/Makefile`).

## Verification
- [x] Standalone shell check of the new `PATCH_VER` resolution logic: `1.30.3 → 1.29.8`, `1.31.3 → 1.31.2`, `1.20.0 → fails loudly` (no lower version available).
- [x] Reproduced the actual failing recipe end-to-end in a throwaway `almalinux:10` container: cloned openresty, applied all 48 `1.29.8` patches against nginx `1.30.3` source (a few already-backported CVE patches were safely skipped by `patch` as "reversed/previously applied", as expected for a stable branch), confirmed `ngx_http_log_escape` now has the correct clean signature, and `./configure && make build` completed successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)