### PR TITLE
chore: ponytail audit cleanup — dead code and duplication

### DIFF
--- a/bin/common.py
+++ b/bin/common.py
@@ -391,33 +391,5 @@ def print_tags(nginx_version, os_distro, os_version):
     print(f"- [`{tag_list}`](https://github.com/fabiocicerchia/nginx-lua/blob/main/{dockerfile_path})")
 
 
-# Backward compatibility aliases
-def get_tags(nginx_ver, os_distro, os_ver, arch):
-    return generate_tags(nginx_ver, os_distro, os_ver, arch)
-
-def get_dockerfile(nginx_ver, os_distro, os_ver):
-    return get_dockerfile_path(nginx_ver, os_distro, os_ver)
-
 def get_supported_os():
     return SUPPORTED_OS
-
-def build(nginx_ver, os_distro, os_ver, arch):
-    return build_image(nginx_ver, os_distro, os_ver, arch)
-
-def push(nginx_ver, os_distro, os_ver):
-    return push_images(nginx_ver, os_distro, os_ver)
-
-def bundle(nginx_ver, os_distro, os_ver):
-    return bundle_images(nginx_ver, os_distro, os_ver)
-
-def metadata(tag):
-    return generate_metadata(tag)
-
-def get_all_versions():
-    return load_supported_versions()
-
-def init_dockerfile(nginx_ver, os_distro, os_ver):
-    return setup_dockerfile(nginx_ver, os_distro, os_ver)
-
-def tag(nginx_ver, os_distro, os_ver):
-    return print_tags(nginx_ver, os_distro, os_ver)

--- a/bin/docker-build.py
+++ b/bin/docker-build.py
@@ -12,10 +12,7 @@ import subprocess
 import common
 import argparse
 
-# Constants
 ARM64_ARCH = "arm64"
-ARM64V8_ARCH = "arm64v8"
-DOCKER_IMAGES_COMMAND = "docker images"
 
 def main():
     parser = argparse.ArgumentParser(description="Build Docker images for nginx-lua")
@@ -33,7 +30,7 @@ def main():
     arch = args.arch
 
     if arch == ARM64_ARCH:
-        arch = ARM64V8_ARCH
+        arch = common.ARM64V8_ARCH
 
     versions = common.load_supported_versions()
 
@@ -50,7 +47,7 @@ def main():
         sys.exit(1)
 
     stdout = subprocess.check_output(
-        DOCKER_IMAGES_COMMAND.split(), text=True
+        common.DOCKER_IMAGES_COMMAND.split(), text=True
     )
     print(stdout)
 

--- a/bin/generate-dockerfiles.py
+++ b/bin/generate-dockerfiles.py
@@ -9,8 +9,8 @@ versions for each supported OS distribution.
 
 import shutil
 import common
-import subprocess
 import re
+from pathlib import Path
 
 def main():
     versions = common.load_supported_versions()
@@ -21,11 +21,10 @@ def main():
     for os_distro in common.get_supported_os():
         common.setup_dockerfile(versions["nginx_stable"], os_distro, versions[os_distro])
 
-    dockerfiles = subprocess.check_output(['/usr/bin/find', 'nginx', '-type', 'f', '-name', 'Dockerfile'])
-    dockerfiles = list(
-        filter(
-            lambda elem: re.search(r"nginx/.+/alpine/\d+\.\d+\.\d+/", elem),
-            dockerfiles.decode("utf-8").split("\n")))
+    dockerfiles = [
+        str(path) for path in Path("nginx").rglob("Dockerfile")
+        if re.search(r"nginx/.+/alpine/\d+\.\d+\.\d+/", str(path))
+    ]
     dockerfiles.sort(reverse=True)
     shutil.copyfile(dockerfiles[0], "./Dockerfile")
 

--- a/bin/generate-supported-versions.py
+++ b/bin/generate-supported-versions.py
@@ -112,11 +112,6 @@ def fetch_stable(distro: str, filter_pattern: str = "") -> Optional[str]:
     return fetch_specific(distro, filter_pattern, "stable")
 
 
-def fetch_latest(distro: str, filter_pattern: str = "") -> Optional[str]:
-    """Fetch latest version."""
-    return fetch_specific(distro, filter_pattern, "latest")
-
-
 def main():
     """Main function to generate supported versions."""
     # Create temp directory if it doesn't exist
@@ -142,32 +137,32 @@ def main():
         print("Wrong version count in NGINX (stable).")
         sys.exit(1)
 
-    ver_almalinux = fetch_latest("almalinux", r"^[0-9]{1,2}\.[0-9]{1,2}-[0-9]{8}$")
+    ver_almalinux = fetch_specific("almalinux", r"^[0-9]{1,2}\.[0-9]{1,2}-[0-9]{8}$")
     if not ver_almalinux:
         print("Wrong version count in ALMALINUX.")
         sys.exit(1)
 
-    ver_alpine = fetch_latest("alpine", r"^[0-9]\.[0-9]{1,2}\.[0-9]{1,2}$")
+    ver_alpine = fetch_specific("alpine", r"^[0-9]\.[0-9]{1,2}\.[0-9]{1,2}$")
     if not ver_alpine:
         print("Wrong version count in ALPINE.")
         sys.exit(1)
 
-    ver_amazonlinux = fetch_latest("amazonlinux", r"^202[3-9]\.[0-9]{1,2}\.[0-9]{8}(\.[0-9])?$")
+    ver_amazonlinux = fetch_specific("amazonlinux", r"^202[3-9]\.[0-9]{1,2}\.[0-9]{8}(\.[0-9])?$")
     if not ver_amazonlinux:
         print("Wrong version count in AMAZONLINUX.")
         sys.exit(1)
 
-    ver_debian = fetch_latest("debian", r"^[0-9]{2}\.[0-9]{1,2}")
+    ver_debian = fetch_specific("debian", r"^[0-9]{2}\.[0-9]{1,2}")
     if not ver_debian:
         print("Wrong version count in DEBIAN.")
         sys.exit(1)
 
-    ver_fedora = fetch_latest("fedora", r"^[0-9]{2}$")
+    ver_fedora = fetch_specific("fedora", r"^[0-9]{2}$")
     if not ver_fedora:
         print("Wrong version count in FEDORA.")
         sys.exit(1)
 
-    ver_ubuntu = fetch_latest("ubuntu", r"^[0-9]{2}\.[0-9]{2}")
+    ver_ubuntu = fetch_specific("ubuntu", r"^[0-9]{2}\.[0-9]{2}")
     if not ver_ubuntu:
         print("Wrong version count in UBUNTU.")
         sys.exit(1)

--- a/bin/generate_tags.py
+++ b/bin/generate_tags.py
@@ -9,12 +9,11 @@ a markdown-formatted list of tags organized by supported and unsupported version
 
 import operator
 import re
-import subprocess
+from pathlib import Path
 import common
 
 # Constants
 DOCKERFILE_PATTERN = "Dockerfile*"
-FIND_COMMAND = ['/usr/bin/find', 'nginx', '-type', 'f', '-name', DOCKERFILE_PATTERN]
 DOCKERFILE_REGEX = r"nginx/(.+)/(.+)/(.+)/Dockerfile(-compat)?"
 COMPAT_SUFFIX = "-compat"
 ALPINE_DISTRO = "alpine"
@@ -24,9 +23,7 @@ LATEST_TAG = "latest"
 GITHUB_BASE_URL = "https://github.com/fabiocicerchia/nginx-lua/blob/main/"
 
 def main():
-    files = sorted(
-        subprocess.check_output(FIND_COMMAND, text=True).splitlines()
-    )
+    files = sorted(str(path) for path in Path("nginx").rglob(DOCKERFILE_PATTERN) if path.is_file())
 
     supported = common.get_supported_versions()
 

--- a/bin/lib-retry.sh
+++ b/bin/lib-retry.sh
@@ -1,0 +1,28 @@
+# Shared by bin/sign-image.sh and bin/sign-manifest.sh.
+# Retry a command with exponential backoff on Docker rate-limit errors (HTTP 429 / TOOMANYREQUESTS).
+retry_on_rate_limit() {
+    local max_retries="${SIGN_MAX_RETRIES:-4}"
+    local delay=2
+    local attempt=0
+    local output_file
+    output_file=$(mktemp /tmp/retry-output-XXXXXX)
+    while true; do
+        local rc=0
+        "$@" > "$output_file" 2>&1 || rc=$?
+        if [ $rc -eq 0 ]; then
+            cat "$output_file"
+            rm -f "$output_file"
+            return 0
+        fi
+        if grep -qi "TOOMANYREQUESTS\|rate limit\|429" "$output_file" && [ $attempt -lt "$max_retries" ]; then
+            attempt=$((attempt + 1))
+            echo "Rate limited – retrying in ${delay}s (attempt ${attempt}/${max_retries})…"
+            sleep $delay
+            delay=$((delay * 2))
+        else
+            cat "$output_file"
+            rm -f "$output_file"
+            return $rc
+        fi
+    done
+}

--- a/bin/sign-image.sh
+++ b/bin/sign-image.sh
@@ -19,33 +19,7 @@
 # Ref: https://github.com/CircleCI-Public/sign-and-publish-examples
 set -euo pipefail
 
-# Retry a command with exponential backoff on Docker rate-limit errors (HTTP 429 / TOOMANYREQUESTS).
-retry_on_rate_limit() {
-    local max_retries="${SIGN_MAX_RETRIES:-4}"
-    local delay=2
-    local attempt=0
-    local output_file
-    output_file=$(mktemp /tmp/retry-output-XXXXXX)
-    while true; do
-        local rc=0
-        "$@" > "$output_file" 2>&1 || rc=$?
-        if [ $rc -eq 0 ]; then
-            cat "$output_file"
-            rm -f "$output_file"
-            return 0
-        fi
-        if grep -qi "TOOMANYREQUESTS\|rate limit\|429" "$output_file" && [ $attempt -lt "$max_retries" ]; then
-            attempt=$((attempt + 1))
-            echo "Rate limited – retrying in ${delay}s (attempt ${attempt}/${max_retries})…"
-            sleep $delay
-            delay=$((delay * 2))
-        else
-            cat "$output_file"
-            rm -f "$output_file"
-            return $rc
-        fi
-    done
-}
+source "$(dirname "${BASH_SOURCE[0]}")/lib-retry.sh"
 
 IMAGE_REF="$1"
 VCS_REF=${VCS_REF:-$(git rev-parse --short HEAD)}

--- a/bin/sign-manifest.sh
+++ b/bin/sign-manifest.sh
@@ -22,33 +22,7 @@
 # Ref: NIS2 Article 21(2)(d) - supply chain security
 set -euo pipefail
 
-# Retry a command with exponential backoff on Docker rate-limit errors (HTTP 429 / TOOMANYREQUESTS).
-retry_on_rate_limit() {
-    local max_retries="${SIGN_MAX_RETRIES:-4}"
-    local delay=2
-    local attempt=0
-    local output_file
-    output_file=$(mktemp /tmp/retry-output-XXXXXX)
-    while true; do
-        local rc=0
-        "$@" > "$output_file" 2>&1 || rc=$?
-        if [ $rc -eq 0 ]; then
-            cat "$output_file"
-            rm -f "$output_file"
-            return 0
-        fi
-        if grep -qi "TOOMANYREQUESTS\|rate limit\|429" "$output_file" && [ $attempt -lt "$max_retries" ]; then
-            attempt=$((attempt + 1))
-            echo "Rate limited – retrying in ${delay}s (attempt ${attempt}/${max_retries})…"
-            sleep $delay
-            delay=$((delay * 2))
-        else
-            cat "$output_file"
-            rm -f "$output_file"
-            return $rc
-        fi
-    done
-}
+source "$(dirname "${BASH_SOURCE[0]}")/lib-retry.sh"
 
 IMAGE_REF="$1"
 VCS_REF=${VCS_REF:-$(git rev-parse --short HEAD)}


### PR DESCRIPTION
## Summary
Cleanup from a repo-wide over-engineering audit (`bin/` scripts only — no behavior changes intended, verified where applicable).

- Remove 9 unused "backward compatibility alias" functions in `bin/common.py` (`get_tags`, `get_dockerfile`, `build`, `push`, `bundle`, `metadata`, `get_all_versions`, `init_dockerfile`, `tag`) — zero callers anywhere in the repo.
- `bin/docker-build.py`: reuse `common.ARM64V8_ARCH` / `common.DOCKER_IMAGES_COMMAND` instead of redeclaring them locally.
- `bin/generate-supported-versions.py`: drop `fetch_latest()` — it was a no-op wrapper since `fetch_specific()`'s `specific_tag` already defaults to `"latest"`.
- Extract the identical `retry_on_rate_limit()` helper duplicated in `bin/sign-image.sh` and `bin/sign-manifest.sh` into a shared `bin/lib-retry.sh`, sourced by both.
- `bin/generate-dockerfiles.py` / `bin/generate_tags.py`: replace `subprocess.check_output(['/usr/bin/find', ...])` with `pathlib.Path.rglob()` — verified to produce byte-identical file listings against the current tree.

Each change is its own commit for easy review.

## Test plan
- [x] `python3 -m py_compile` on all touched `.py` files
- [x] `bash -n` on both touched `.sh` files
- [x] grep verified no remaining references to removed functions/wrappers
- [x] Confirmed `Path.rglob()` output is identical to the old `find`-based output on the current `nginx/` tree
- [ ] CI (build/push/sign jobs use these scripts; not exercised locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)