### PR TITLE
fix: sync fossa-deps.yml with actual pinned dependency versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ $(packagetest_targets_arm64): ## testing the system package in arm64/v8 arch
 ################################################################################
 ##@ UTILITIES
 ################################################################################
-auto-update: generate-supported-versions pull-nginx-entrypoints generate-deps-env generate-dockerfiles update-readme update-tags ## auto update supported versions, dockerfiles and tags
+auto-update: generate-supported-versions pull-nginx-entrypoints generate-deps-env generate-dockerfiles generate-fossa-deps update-readme update-tags ## auto update supported versions, dockerfiles, fossa deps and tags
 
 .setup_gitrepo:
 	git config user.name "$(GH_USERNAME)"
@@ -245,7 +245,7 @@ auto-update: generate-supported-versions pull-nginx-entrypoints generate-deps-en
 	git remote set-url --push origin "https://x-access-token:${GITHUB_TOKEN}@github.com/$(GH_USERNAME)/nginx-lua.git"
 
 auto-update-and-commit: .setup_gitrepo auto-update
-	git add supported_versions nginx/ src/ docs/TAGS.md README.md || true; \
+	git add supported_versions nginx/ src/ docs/TAGS.md README.md fossa-deps.yml || true; \
 	CHANGES=$$(git status --porcelain | wc -l | tr -d ' '); \
 	if [ "$$CHANGES" = "0" ]; then \
 		exit 1; \
@@ -313,6 +313,9 @@ generate-dockerfiles: ## generate all dockerfiles
 
 generate-deps-env: ## generate .env for dependencies
 	./bin/generate-deps-env.py | tee ./src/.env.dist
+
+generate-fossa-deps: ## regenerate fossa-deps.yml from src/.env.dist
+	./bin/generate-fossa-deps.py
 
 ENTRYPOINT_FILES=src/10-listen-on-ipv6-by-default.sh src/15-local-resolvers.envsh src/20-envsubst-on-templates.sh src/30-tune-worker-processes.sh src/docker-entrypoint.sh
 ENTRYPOINT_CHECKSUMS=src/entrypoint-checksums.sha256

--- a/bin/deps_manifest.py
+++ b/bin/deps_manifest.py
@@ -1,0 +1,108 @@
+"""
+Single source of truth for third-party nginx/Lua module dependencies.
+
+Used by generate-deps-env.py (resolves latest versions -> src/.env.dist) and
+generate-fossa-deps.py (reads src/.env.dist -> fossa-deps.yml), so both stay
+in sync automatically instead of drifting apart.
+
+Fields:
+    key:             lowercase identifier; VER_<KEY.upper()> is the .env.dist variable.
+    fossa_name:      display name used in fossa-deps.yml.
+    repo_url:        GitHub repo URL (no trailing slash).
+    is_commit:       True if pinned to a commit SHA instead of a tag (tracks a branch).
+    tarball_pattern: archive URL template, {ver} is the tag/commit.
+"""
+
+DEPENDENCIES = [
+    dict(key='ngx_devel_kit', fossa_name='ngx_devel_kit',
+         repo_url="https://github.com/vision5/ngx_devel_kit", is_commit=False,
+         tarball_pattern="https://github.com/vision5/ngx_devel_kit/archive/v{ver}.tar.gz"),
+    dict(key='njs', fossa_name='njs',
+         repo_url="https://github.com/nginx/njs", is_commit=False,
+         tarball_pattern="https://github.com/nginx/njs/archive/{ver}.tar.gz"),
+    dict(key='geoip', fossa_name='geoip2',
+         repo_url="https://github.com/leev/ngx_http_geoip2_module", is_commit=False,
+         tarball_pattern="https://github.com/leev/ngx_http_geoip2_module/archive/{ver}.tar.gz"),
+    dict(key='luajit', fossa_name='luajit2',
+         repo_url="https://github.com/openresty/luajit2", is_commit=False,
+         tarball_pattern="https://github.com/openresty/luajit2/archive/v{ver}.tar.gz"),
+    dict(key='lua_nginx_module', fossa_name='lua-nginx-module',
+         repo_url="https://github.com/openresty/lua-nginx-module", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-nginx-module/archive/v{ver}.tar.gz"),
+    dict(key='lua_resty_core', fossa_name='lua-resty-core',
+         repo_url="https://github.com/openresty/lua-resty-core", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-resty-core/archive/v{ver}.tar.gz"),
+    dict(key='luarocks', fossa_name='lua-rocks',
+         repo_url="https://github.com/luarocks/luarocks", is_commit=False,
+         tarball_pattern="https://github.com/luarocks/luarocks/archive/refs/tags/v{ver}.tar.gz"),
+    dict(key='lua_resty_lrucache', fossa_name='lua-resty-lrucache',
+         repo_url="https://github.com/openresty/lua-resty-lrucache", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-resty-lrucache/archive/v{ver}.tar.gz"),
+    dict(key='openresty_headers', fossa_name='headers-more-nginx-module',
+         repo_url="https://github.com/openresty/headers-more-nginx-module", is_commit=False,
+         tarball_pattern="https://github.com/openresty/headers-more-nginx-module/archive/v{ver}.tar.gz"),
+    dict(key='cloudflare_cookie', fossa_name='lua-resty-cookie',
+         repo_url="https://github.com/cloudflare/lua-resty-cookie", is_commit=True,
+         tarball_pattern="https://github.com/cloudflare/lua-resty-cookie/archive/{ver}.tar.gz"),
+    dict(key='openresty_dns', fossa_name='lua-resty-dns',
+         repo_url="https://github.com/openresty/lua-resty-dns", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-resty-dns/archive/v{ver}.tar.gz"),
+    dict(key='openresty_memcached', fossa_name='lua-resty-memcached',
+         repo_url="https://github.com/openresty/lua-resty-memcached", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-resty-memcached/archive/v{ver}.tar.gz"),
+    dict(key='openresty_mysql', fossa_name='lua-resty-mysql',
+         repo_url="https://github.com/openresty/lua-resty-mysql", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-resty-mysql/archive/v{ver}.tar.gz"),
+    dict(key='openresty_redis', fossa_name='lua-resty-redis',
+         repo_url="https://github.com/openresty/lua-resty-redis", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-resty-redis/archive/v{ver}.tar.gz"),
+    dict(key='openresty_shell', fossa_name='lua-resty-shell',
+         repo_url="https://github.com/openresty/lua-resty-shell", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-resty-shell/archive/v{ver}.tar.gz"),
+    dict(key='openresty_signal', fossa_name='lua-resty-signal',
+         repo_url="https://github.com/openresty/lua-resty-signal", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-resty-signal/archive/v{ver}.tar.gz"),
+    dict(key='openresty_tablepool', fossa_name='lua-tablepool',
+         repo_url="https://github.com/openresty/lua-tablepool", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-tablepool/archive/v{ver}.tar.gz"),
+    dict(key='openresty_healthcheck', fossa_name='lua-resty-upstream-healthcheck',
+         repo_url="https://github.com/openresty/lua-resty-upstream-healthcheck", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-resty-upstream-healthcheck/archive/v{ver}.tar.gz"),
+    dict(key='openresty_websocket', fossa_name='lua-resty-websocket',
+         repo_url="https://github.com/openresty/lua-resty-websocket", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-resty-websocket/archive/v{ver}.tar.gz"),
+    dict(key='lua_upstream', fossa_name='lua-upstream-nginx-module',
+         repo_url="https://github.com/openresty/lua-upstream-nginx-module", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-upstream-nginx-module/archive/v{ver}.tar.gz"),
+    dict(key='prometheus', fossa_name='nginx-lua-prometheus',
+         repo_url="https://github.com/knyar/nginx-lua-prometheus", is_commit=False,
+         tarball_pattern="https://github.com/knyar/nginx-lua-prometheus/archive/{ver}.tar.gz"),
+    dict(key='misc_nginx', fossa_name='set-misc-nginx-module',
+         repo_url="https://github.com/openresty/set-misc-nginx-module", is_commit=False,
+         tarball_pattern="https://github.com/openresty/set-misc-nginx-module/archive/v{ver}.tar.gz"),
+    dict(key='openresty_streamlua', fossa_name='stream-lua-nginx-module',
+         repo_url="https://github.com/openresty/stream-lua-nginx-module", is_commit=True,
+         tarball_pattern="https://github.com/openresty/stream-lua-nginx-module/archive/{ver}.tar.gz"),
+    dict(key='openresty_limittraffic', fossa_name='lua-resty-limit-traffic',
+         repo_url="https://github.com/openresty/lua-resty-limit-traffic", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-resty-limit-traffic/archive/v{ver}.tar.gz"),
+    dict(key='openresty_upload', fossa_name='lua-resty-upload',
+         repo_url="https://github.com/openresty/lua-resty-upload", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-resty-upload/archive/v{ver}.tar.gz"),
+    dict(key='openresty_lock', fossa_name='lua-resty-lock',
+         repo_url="https://github.com/openresty/lua-resty-lock", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-resty-lock/archive/v{ver}.tar.gz"),
+    dict(key='openresty_balancer', fossa_name='lua-resty-balancer',
+         repo_url="https://github.com/openresty/lua-resty-balancer", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-resty-balancer/archive/v{ver}.tar.gz"),
+    dict(key='openresty_string', fossa_name='lua-resty-string',
+         repo_url="https://github.com/openresty/lua-resty-string", is_commit=False,
+         tarball_pattern="https://github.com/openresty/lua-resty-string/archive/v{ver}.tar.gz"),
+]
+
+# Vendored file with no version to track (not in src/.env.dist) - kept static.
+STATIC_DEPENDENCIES = [
+    dict(fossa_name="SSL implementation by Eric Young",
+         url="https://raw.githubusercontent.com/vision5/ngx_devel_kit/refs/heads/master/src/hash/sha.h",
+         version="0.0.0"),
+]

--- a/bin/generate-deps-env.py
+++ b/bin/generate-deps-env.py
@@ -15,6 +15,8 @@ from urllib.parse import urlparse
 
 import requests
 
+from deps_manifest import DEPENDENCIES
+
 
 def compute_sha256(url):
     """Download a file and compute its SHA256 hash. Returns 'RECOMPUTE_REQUIRED' on failure."""
@@ -116,65 +118,11 @@ def main():
     # Load template
     template = load_template()
 
-    # Define dependencies: key -> (repo_url, is_commit, tarball_url_pattern)
-    # tarball_url_pattern uses {ver} as placeholder for the version
+    # Dependency list (repo, tarball URL pattern, ...) lives in deps_manifest.py,
+    # shared with generate-fossa-deps.py so both stay in sync.
     deps = [
-        ('ngx_devel_kit', "https://github.com/vision5/ngx_devel_kit", False,
-         "https://github.com/vision5/ngx_devel_kit/archive/v{ver}.tar.gz"),
-        ('njs', "https://github.com/nginx/njs", False,
-         "https://github.com/nginx/njs/archive/{ver}.tar.gz"),
-        ('geoip', "https://github.com/leev/ngx_http_geoip2_module", False,
-         "https://github.com/leev/ngx_http_geoip2_module/archive/{ver}.tar.gz"),
-        ('luajit', "https://github.com/openresty/luajit2", False,
-         "https://github.com/openresty/luajit2/archive/v{ver}.tar.gz"),
-        ('lua_nginx_module', "https://github.com/openresty/lua-nginx-module", False,
-         "https://github.com/openresty/lua-nginx-module/archive/v{ver}.tar.gz"),
-        ('lua_resty_core', "https://github.com/openresty/lua-resty-core", False,
-         "https://github.com/openresty/lua-resty-core/archive/v{ver}.tar.gz"),
-        ('luarocks', "https://github.com/luarocks/luarocks", False,
-         "https://github.com/luarocks/luarocks/archive/refs/tags/v{ver}.tar.gz"),
-        ('lua_resty_lrucache', "https://github.com/openresty/lua-resty-lrucache", False,
-         "https://github.com/openresty/lua-resty-lrucache/archive/v{ver}.tar.gz"),
-        ('openresty_headers', "https://github.com/openresty/headers-more-nginx-module", False,
-         "https://github.com/openresty/headers-more-nginx-module/archive/v{ver}.tar.gz"),
-        ('cloudflare_cookie', "https://github.com/cloudflare/lua-resty-cookie", True,
-         "https://github.com/cloudflare/lua-resty-cookie/archive/{ver}.tar.gz"),
-        ('openresty_dns', "https://github.com/openresty/lua-resty-dns", False,
-         "https://github.com/openresty/lua-resty-dns/archive/v{ver}.tar.gz"),
-        ('openresty_memcached', "https://github.com/openresty/lua-resty-memcached", False,
-         "https://github.com/openresty/lua-resty-memcached/archive/v{ver}.tar.gz"),
-        ('openresty_mysql', "https://github.com/openresty/lua-resty-mysql", False,
-         "https://github.com/openresty/lua-resty-mysql/archive/v{ver}.tar.gz"),
-        ('openresty_redis', "https://github.com/openresty/lua-resty-redis", False,
-         "https://github.com/openresty/lua-resty-redis/archive/v{ver}.tar.gz"),
-        ('openresty_shell', "https://github.com/openresty/lua-resty-shell", False,
-         "https://github.com/openresty/lua-resty-shell/archive/v{ver}.tar.gz"),
-        ('openresty_signal', "https://github.com/openresty/lua-resty-signal", False,
-         "https://github.com/openresty/lua-resty-signal/archive/v{ver}.tar.gz"),
-        ('openresty_tablepool', "https://github.com/openresty/lua-tablepool", False,
-         "https://github.com/openresty/lua-tablepool/archive/v{ver}.tar.gz"),
-        ('openresty_healthcheck', "https://github.com/openresty/lua-resty-upstream-healthcheck", False,
-         "https://github.com/openresty/lua-resty-upstream-healthcheck/archive/v{ver}.tar.gz"),
-        ('openresty_websocket', "https://github.com/openresty/lua-resty-websocket", False,
-         "https://github.com/openresty/lua-resty-websocket/archive/v{ver}.tar.gz"),
-        ('lua_upstream', "https://github.com/openresty/lua-upstream-nginx-module", False,
-         "https://github.com/openresty/lua-upstream-nginx-module/archive/v{ver}.tar.gz"),
-        ('prometheus', "https://github.com/knyar/nginx-lua-prometheus", False,
-         "https://github.com/knyar/nginx-lua-prometheus/archive/{ver}.tar.gz"),
-        ('misc_nginx', "https://github.com/openresty/set-misc-nginx-module", False,
-         "https://github.com/openresty/set-misc-nginx-module/archive/v{ver}.tar.gz"),
-        ('openresty_streamlua', "https://github.com/openresty/stream-lua-nginx-module", True,
-         "https://github.com/openresty/stream-lua-nginx-module/archive/{ver}.tar.gz"),
-        ('openresty_limittraffic', "https://github.com/openresty/lua-resty-limit-traffic", False,
-         "https://github.com/openresty/lua-resty-limit-traffic/archive/v{ver}.tar.gz"),
-        ('openresty_upload', "https://github.com/openresty/lua-resty-upload", False,
-         "https://github.com/openresty/lua-resty-upload/archive/v{ver}.tar.gz"),
-        ('openresty_lock', "https://github.com/openresty/lua-resty-lock", False,
-         "https://github.com/openresty/lua-resty-lock/archive/v{ver}.tar.gz"),
-        ('openresty_balancer', "https://github.com/openresty/lua-resty-balancer", False,
-         "https://github.com/openresty/lua-resty-balancer/archive/v{ver}.tar.gz"),
-        ('openresty_string', "https://github.com/openresty/lua-resty-string", False,
-         "https://github.com/openresty/lua-resty-string/archive/v{ver}.tar.gz"),
+        (dep['key'], dep['repo_url'], dep['is_commit'], dep['tarball_pattern'])
+        for dep in DEPENDENCIES
     ]
 
     template_vars = {}

--- a/bin/generate-fossa-deps.py
+++ b/bin/generate-fossa-deps.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Generate fossa-deps.yml from src/.env.dist.
+
+Keeps FOSSA's remote-dependencies manifest (used for license/vuln scanning of
+the vendored nginx/Lua modules) in sync with the versions actually pinned in
+the Dockerfiles, instead of drifting out of date by hand.
+"""
+
+import sys
+from pathlib import Path
+
+from deps_manifest import DEPENDENCIES, STATIC_DEPENDENCIES
+
+ENV_DIST_PATH = Path(__file__).parent.parent / "src" / ".env.dist"
+FOSSA_DEPS_PATH = Path(__file__).parent.parent / "fossa-deps.yml"
+
+
+def load_env_dist():
+    """Parse VER_* values out of src/.env.dist."""
+    versions = {}
+    for line in ENV_DIST_PATH.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            key, value = line.split("=", 1)
+            versions[key] = value
+    return versions
+
+
+def main():
+    versions = load_env_dist()
+
+    lines = ["remote-dependencies:"]
+    for dep in DEPENDENCIES:
+        env_key = f"VER_{dep['key'].upper()}"
+        if env_key not in versions:
+            print(f"ERROR: {env_key} not found in {ENV_DIST_PATH}", file=sys.stderr)
+            sys.exit(1)
+        ver = versions[env_key]
+        url = dep['tarball_pattern'].format(ver=ver)
+        ref = "commits/master" if dep['is_commit'] else "tags"
+        lines.append(f"# {dep['repo_url']}/{ref}")
+        lines.append(f"- name: {dep['fossa_name']}")
+        lines.append(f'  url: "{url}"')
+        lines.append(f'  version: "{ver}"')
+        lines.append("")
+
+    for dep in STATIC_DEPENDENCIES:
+        lines.append(f'- name: "{dep["fossa_name"]}"')
+        lines.append(f'  url: "{dep["url"]}"')
+        lines.append(f'  version: "{dep["version"]}"')
+        lines.append("")
+
+    FOSSA_DEPS_PATH.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+    print(f"Wrote {FOSSA_DEPS_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/fossa-deps.yml
+++ b/fossa-deps.yml
@@ -1,144 +1,144 @@
 remote-dependencies:
-# https://github.com/vision5/ngx_devel_kit/releases
+# https://github.com/vision5/ngx_devel_kit/tags
 - name: ngx_devel_kit
-  url: "https://github.com/vision5/ngx_devel_kit/archive/refs/tags/v0.3.4.zip"
+  url: "https://github.com/vision5/ngx_devel_kit/archive/v0.3.4.tar.gz"
   version: "0.3.4"
 
 # https://github.com/nginx/njs/tags
 - name: njs
-  url: "https://github.com/nginx/njs/archive/refs/tags/0.9.1.zip"
-  version: "0.9.1"
+  url: "https://github.com/nginx/njs/archive/1.0.0.tar.gz"
+  version: "1.0.0"
 
-# https://github.com/leev/ngx_http_geoip2_module/releases
+# https://github.com/leev/ngx_http_geoip2_module/tags
 - name: geoip2
-  url: "https://github.com/leev/ngx_http_geoip2_module/archive/refs/tags/3.4.zip"
+  url: "https://github.com/leev/ngx_http_geoip2_module/archive/3.4.tar.gz"
   version: "3.4"
 
 # https://github.com/openresty/luajit2/tags
 - name: luajit2
-  url: "https://github.com/leev/ngx_http_geoip2_module/releases"
-  version: "2.1-20250529"
+  url: "https://github.com/openresty/luajit2/archive/v2.1-20260701.tar.gz"
+  version: "2.1-20260701"
 
 # https://github.com/openresty/lua-nginx-module/tags
 - name: lua-nginx-module
-  url: "https://github.com/openresty/lua-nginx-module/archive/refs/tags/v0.10.28.zip"
-  version: "0.10.28"
+  url: "https://github.com/openresty/lua-nginx-module/archive/v0.10.29.tar.gz"
+  version: "0.10.29"
 
 # https://github.com/openresty/lua-resty-core/tags
 - name: lua-resty-core
-  url: "https://github.com/openresty/lua-nginx-module/tags"
-  version: "0.1.31"
+  url: "https://github.com/openresty/lua-resty-core/archive/v0.1.32.tar.gz"
+  version: "0.1.32"
 
 # https://github.com/luarocks/luarocks/tags
 - name: lua-rocks
-  url: "https://github.com/luarocks/luarocks/archive/refs/tags/v3.12.2.zip"
-  version: "3.12.2"
+  url: "https://github.com/luarocks/luarocks/archive/refs/tags/v3.13.0.tar.gz"
+  version: "3.13.0"
 
 # https://github.com/openresty/lua-resty-lrucache/tags
 - name: lua-resty-lrucache
-  url: "https://github.com/openresty/lua-resty-lrucache/archive/refs/tags/v0.15.zip"
+  url: "https://github.com/openresty/lua-resty-lrucache/archive/v0.15.tar.gz"
   version: "0.15"
 
 # https://github.com/openresty/headers-more-nginx-module/tags
 - name: headers-more-nginx-module
-  url: "https://github.com/openresty/headers-more-nginx-module/archive/refs/tags/v0.39.zip"
-  version: "0.39"
+  url: "https://github.com/openresty/headers-more-nginx-module/archive/v0.40.tar.gz"
+  version: "0.40"
 
 # https://github.com/cloudflare/lua-resty-cookie/commits/master
 - name: lua-resty-cookie
-  url: "https://github.com/cloudflare/lua-resty-cookie/archive/refs/heads/master.zip"
+  url: "https://github.com/cloudflare/lua-resty-cookie/archive/f418d77082eaef48331302e84330488fdc810ef4.tar.gz"
   version: "f418d77082eaef48331302e84330488fdc810ef4"
 
 # https://github.com/openresty/lua-resty-dns/tags
 - name: lua-resty-dns
-  url: "https://github.com/openresty/lua-resty-dns/archive/refs/tags/v0.23.zip"
+  url: "https://github.com/openresty/lua-resty-dns/archive/v0.23.tar.gz"
   version: "0.23"
 
 # https://github.com/openresty/lua-resty-memcached/tags
 - name: lua-resty-memcached
-  url: "https://github.com/openresty/lua-resty-memcached/archive/refs/tags/v0.17.zip"
-  version: "0.17"
+  url: "https://github.com/openresty/lua-resty-memcached/archive/v0.18.tar.gz"
+  version: "0.18"
 
 # https://github.com/openresty/lua-resty-mysql/tags
 - name: lua-resty-mysql
-  url: "https://github.com/openresty/lua-resty-mysql/archive/refs/tags/v0.28.zip"
-  version: "0.28"
-
-- name: SSL implementation by Eric Young
-  url: "https://raw.githubusercontent.com/vision5/ngx_devel_kit/refs/heads/master/src/hash/sha.h"
-  version: "0.0.0"
+  url: "https://github.com/openresty/lua-resty-mysql/archive/v0.31.tar.gz"
+  version: "0.31"
 
 # https://github.com/openresty/lua-resty-redis/tags
 - name: lua-resty-redis
-  url: "https://github.com/openresty/lua-resty-redis/archive/refs/tags/v0.33.zip"
+  url: "https://github.com/openresty/lua-resty-redis/archive/v0.33.tar.gz"
   version: "0.33"
 
 # https://github.com/openresty/lua-resty-shell/tags
 - name: lua-resty-shell
-  url: "https://github.com/openresty/lua-resty-shell/archive/refs/tags/v0.03.zip"
+  url: "https://github.com/openresty/lua-resty-shell/archive/v0.03.tar.gz"
   version: "0.03"
 
 # https://github.com/openresty/lua-resty-signal/tags
 - name: lua-resty-signal
-  url: "https://github.com/openresty/lua-resty-signal/archive/refs/tags/v0.04.zip"
-  version: "0.04"
+  url: "https://github.com/openresty/lua-resty-signal/archive/v0.05.tar.gz"
+  version: "0.05"
 
 # https://github.com/openresty/lua-tablepool/tags
 - name: lua-tablepool
-  url: "https://github.com/openresty/lua-tablepool/archive/refs/tags/v0.03.zip"
+  url: "https://github.com/openresty/lua-tablepool/archive/v0.03.tar.gz"
   version: "0.03"
 
 # https://github.com/openresty/lua-resty-upstream-healthcheck/tags
 - name: lua-resty-upstream-healthcheck
-  url: "https://github.com/openresty/lua-resty-upstream-healthcheck/archive/refs/tags/v0.08.zip"
-  version: "0.08"
+  url: "https://github.com/openresty/lua-resty-upstream-healthcheck/archive/v0.10.tar.gz"
+  version: "0.10"
 
 # https://github.com/openresty/lua-resty-websocket/tags
 - name: lua-resty-websocket
-  url: "https://github.com/openresty/lua-resty-websocket/archive/refs/tags/v0.13.zip"
-  version: "0.13"
+  url: "https://github.com/openresty/lua-resty-websocket/archive/v0.14.tar.gz"
+  version: "0.14"
 
 # https://github.com/openresty/lua-upstream-nginx-module/tags
 - name: lua-upstream-nginx-module
-  url: "https://github.com/openresty/lua-upstream-nginx-module/archive/refs/tags/v0.07.zip"
-  version: "0.07"
+  url: "https://github.com/openresty/lua-upstream-nginx-module/archive/v0.08.tar.gz"
+  version: "0.08"
 
 # https://github.com/knyar/nginx-lua-prometheus/tags
 - name: nginx-lua-prometheus
-  url: "https://github.com/knyar/nginx-lua-prometheus/archive/refs/tags/0.20240525.zip"
+  url: "https://github.com/knyar/nginx-lua-prometheus/archive/0.20240525.tar.gz"
   version: "0.20240525"
 
 # https://github.com/openresty/set-misc-nginx-module/tags
 - name: set-misc-nginx-module
-  url: "https://github.com/openresty/set-misc-nginx-module/archive/refs/tags/v0.33.zip"
-  version: "0.33"
+  url: "https://github.com/openresty/set-misc-nginx-module/archive/v0.34.tar.gz"
+  version: "0.34"
 
 # https://github.com/openresty/stream-lua-nginx-module/commits/master
 - name: stream-lua-nginx-module
-  url: "https://github.com/openresty/stream-lua-nginx-module/archive/refs/heads/master.zip"
-  version: "a9addfabbf277eb3d1ec77d45e40a324d67022af"
+  url: "https://github.com/openresty/stream-lua-nginx-module/archive/11f9e38a20dc79783a9d793201d6ec399ff368e7.tar.gz"
+  version: "11f9e38a20dc79783a9d793201d6ec399ff368e7"
 
 # https://github.com/openresty/lua-resty-limit-traffic/tags
 - name: lua-resty-limit-traffic
-  url: "https://github.com/openresty/lua-resty-limit-traffic/archive/refs/tags/v0.09.zip"
+  url: "https://github.com/openresty/lua-resty-limit-traffic/archive/v0.09.tar.gz"
   version: "0.09"
 
 # https://github.com/openresty/lua-resty-upload/tags
 - name: lua-resty-upload
-  url: "https://github.com/openresty/lua-resty-upload/archive/refs/tags/v0.11.zip"
+  url: "https://github.com/openresty/lua-resty-upload/archive/v0.11.tar.gz"
   version: "0.11"
 
 # https://github.com/openresty/lua-resty-lock/tags
 - name: lua-resty-lock
-  url: "https://github.com/openresty/lua-resty-lock/archive/refs/tags/v0.09.zip"
+  url: "https://github.com/openresty/lua-resty-lock/archive/v0.09.tar.gz"
   version: "0.09"
 
 # https://github.com/openresty/lua-resty-balancer/tags
 - name: lua-resty-balancer
-  url: "https://github.com/openresty/lua-resty-balancer/archive/refs/tags/v0.05.zip"
+  url: "https://github.com/openresty/lua-resty-balancer/archive/v0.05.tar.gz"
   version: "0.05"
 
 # https://github.com/openresty/lua-resty-string/tags
 - name: lua-resty-string
-  url: "https://github.com/openresty/lua-resty-string/archive/refs/tags/v0.16.zip"
-  version: "0.16"
+  url: "https://github.com/openresty/lua-resty-string/archive/v0.19.tar.gz"
+  version: "0.19"
+
+- name: "SSL implementation by Eric Young"
+  url: "https://raw.githubusercontent.com/vision5/ngx_devel_kit/refs/heads/master/src/hash/sha.h"
+  version: "0.0.0"


### PR DESCRIPTION
## Summary
- `fossa-deps.yml` was hand-maintained and had drifted badly from what's actually built — e.g. njs was listed as `0.9.1` while the pinned Dockerfile version is `1.0.0`, a full major version behind, along with 13 other stale entries (luajit2, lua-nginx-module, lua-resty-core, lua-rocks, headers-more-nginx-module, lua-resty-memcached, lua-resty-mysql, lua-resty-signal, lua-resty-upstream-healthcheck, lua-resty-websocket, lua-upstream-nginx-module, set-misc-nginx-module, stream-lua-nginx-module, lua-resty-string). This is a likely cause of stale FOSSA license/vulnerability findings.
- Extracted the dependency list (repo URL, tarball pattern, commit-vs-tag) into `bin/deps_manifest.py` as a single source of truth, now shared by `bin/generate-deps-env.py` (already existed) and a new `bin/generate-fossa-deps.py`.
- `generate-fossa-deps.py` regenerates `fossa-deps.yml` directly from `src/.env.dist` (the file `generate-deps-env.py` already produces), so the two files can no longer drift apart.
- Wired `generate-fossa-deps` into the existing nightly `make auto-update` pipeline (run via CircleCI cron -> `auto-update-and-commit`), and added `fossa-deps.yml` to the files that pipeline commits.

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('bin/generate-deps-env.py').read())"` etc. — all three scripts parse cleanly
- [x] Ran `bin/generate-fossa-deps.py` locally against the current `src/.env.dist` and confirmed the regenerated `fossa-deps.yml` now matches the actually pinned versions (njs 1.0.0, etc.)
- [ ] Next nightly `auto-update` CircleCI run picks up `generate-fossa-deps` without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)