### PR TITLE
refactor: elevate-code sweep

### DIFF
--- a/bin/common.py
+++ b/bin/common.py
@@ -5,11 +5,8 @@ Common utilities for nginx-lua Docker image management.
 import glob
 import os
 import re
-import shlex
 import shutil
-import subprocess
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 
 # Configuration
@@ -22,39 +19,10 @@ DIST_DIR = "dist"
 MULTIARCH_PREFIX = "multiarch"
 TARBALL_EXTENSION = ".tar"
 SUPPORTED_VERSIONS_FILE = "supported_versions"
-DOCS_METADATA_DIR = "docs/metadata"
 SRC_DIR = "src"
 TPL_DIR = "tpl"
 PATCHES_DIR = "patches"
 LICENSES_DIR = "licenses"
-
-# Docker constants
-DOCKER_BUILD_COMMAND = "docker build"
-DOCKER_PUSH_COMMAND = "docker push"
-DOCKER_PULL_COMMAND = "docker pull"
-DOCKER_INSPECT_COMMAND = "docker image inspect"
-DOCKER_MANIFEST_CREATE = "docker manifest create"
-DOCKER_MANIFEST_PUSH = "docker manifest push"
-DOCKER_TAG_COMMAND = "docker tag"
-DOCKER_IMAGES_COMMAND = "docker images"
-
-
-# Git constants
-GIT_REV_PARSE_COMMAND = "git rev-parse --short HEAD"
-GIT_COMMIT_DATE_COMMAND = "git log -1 --format=%ct"
-
-# Architecture constants
-AMD64_ARCH = "amd64"
-ARM64V8_ARCH = "arm64v8"
-ARCHITECTURES = [AMD64_ARCH, ARM64V8_ARCH]
-
-# Build arguments
-ARCH_BUILD_ARG = "ARCH"
-BUILD_DATE_BUILD_ARG = "BUILD_DATE"
-VCS_REF_BUILD_ARG = "VCS_REF"
-
-# Date format
-BUILD_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
 
 # String constants
 LATEST_TAG = "latest"
@@ -68,22 +36,6 @@ ENV_DIST_FILE = ".env.dist"
 
 # Configuration files
 CONFIG_FILES = ["default.conf", "Makefile", "nginx.conf"]
-
-
-def run_command(command, print_stdout=True):
-    """Run a shell command and return exit code and output."""
-    print(f"Running: {command}")
-
-    process = subprocess.Popen(
-        shlex.split(command), shell=False, stdout=subprocess.PIPE
-    )
-
-    streamdata = process.communicate()[0]
-    output_lines = streamdata.decode("utf-8")
-    if print_stdout:
-        print(output_lines)
-
-    return [process.returncode, output_lines]
 
 
 def read_file(file_path):
@@ -178,152 +130,6 @@ def get_tarball_path(dockerfile_path):
     """Generate tarball path from Dockerfile path."""
     safe_name = re.sub(SAFE_NAME_PATTERN, SAFE_NAME_REPLACEMENT, dockerfile_path)
     return f"{DIST_DIR}/{MULTIARCH_PREFIX}-{safe_name}{TARBALL_EXTENSION}"
-
-
-def get_build_date():
-    """Derive BUILD_DATE from the current commit's timestamp rather than
-    wall-clock build time.
-
-    Rebuilding the exact same commit (e.g. a CI rerun of a single job,
-    whether same-day or not) then always produces the identical BUILD_DATE
-    build-arg, so the resulting image digest is identical too. A rerun
-    becomes a genuine no-op instead of silently pushing a new, unsigned
-    digest under an already-signed tag and orphaning the earlier signature.
-    """
-    commit_epoch = subprocess.check_output(
-        shlex.split(GIT_COMMIT_DATE_COMMAND), text=True
-    ).strip()
-    return datetime.fromtimestamp(int(commit_epoch), tz=timezone.utc).strftime(
-        BUILD_DATE_FORMAT
-    )
-
-
-def build_docker_image(vcs_ref, tags, dockerfile_path, arch):
-    """Build Docker image with given parameters."""
-    tag_params = " ".join([f"-t {tag}" for tag in tags])
-    build_date = get_build_date()
-
-    tarball_path = get_tarball_path(dockerfile_path)
-    os.makedirs(os.path.dirname(tarball_path), exist_ok=True)
-
-    build_command = f"""
-        {DOCKER_BUILD_COMMAND}
-        --progress=plain
-        --build-arg {ARCH_BUILD_ARG}="{arch}"
-        --build-arg {BUILD_DATE_BUILD_ARG}="{build_date}"
-        --build-arg {VCS_REF_BUILD_ARG}="{vcs_ref}"
-        {tag_params}
-        -f {dockerfile_path} {os.path.dirname(dockerfile_path)}
-    """
-
-    return run_command(build_command, True)[0]
-
-
-def build_image(nginx_version, os_distro, os_version, arch):
-    """Build Docker image for given configuration."""
-    dockerfile_path = get_dockerfile_path(nginx_version, os_distro, os_version)
-    tags = generate_tags(nginx_version, os_distro, os_version, arch)
-    vcs_ref = subprocess.check_output(
-        shlex.split(GIT_REV_PARSE_COMMAND), text=True
-    ).strip()
-
-    return build_docker_image(vcs_ref, tags, dockerfile_path, arch)
-
-
-def push_docker_image(tag):
-    """Push Docker image to registry with retry."""
-    cmd = f"{DOCKER_PUSH_COMMAND} {tag}"
-    exit_code = run_command(cmd, True)[0]
-
-    # Retry once if failed
-    if exit_code != 0:
-        exit_code = run_command(cmd, True)[0]
-
-    return exit_code
-
-
-def push_images(nginx_version, os_distro, os_version, arch=None):
-    """Push per-arch images to the registry.
-
-    Pushes images directly (without -unsigned suffix) since signing is
-    done on the multi-arch manifest list after bundling, not on per-arch
-    images.
-
-    If arch is provided, only images for that architecture are processed.
-    This is the expected behaviour in CI where each runner builds only
-    for its own architecture.
-    """
-    arches = [arch] if arch else ARCHITECTURES
-    for current_arch in arches:
-        tags = generate_tags(nginx_version, os_distro, os_version, current_arch)
-        for tag in tags:
-            exit_code = push_docker_image(tag)
-            if exit_code != 0:
-                print(f"FATAL: Failed to push image {tag}")
-                return exit_code
-
-    return 0
-
-
-def create_manifest(tag):
-    """Create and push multi-arch manifest."""
-    tag_amd64 = f"{tag}-{AMD64_ARCH}"
-    tag_arm64 = f"{tag}-{ARM64V8_ARCH}"
-
-    # Create manifest
-    create_cmd = f"""
-        {DOCKER_MANIFEST_CREATE}
-        {tag}
-        --amend {tag_amd64}
-        --amend {tag_arm64}
-    """
-    exit_code = run_command(create_cmd, True)[0]
-    if exit_code != 0:
-        return 1
-
-    # Push manifest
-    push_cmd = f"{DOCKER_MANIFEST_PUSH} {tag}"
-    return run_command(push_cmd, True)[0]
-
-
-def bundle_images(nginx_version, os_distro, os_version):
-    """Create multi-arch manifests for all tags."""
-    tags = generate_tags(nginx_version, os_distro, os_version, "")
-
-    for tag in tags:
-        exit_code = create_manifest(tag)
-        if exit_code != 0:
-            return 1
-
-    return 0
-
-
-def generate_metadata(tag):
-    """Generate metadata documentation for image tag.
-
-    Tries to inspect the image locally first to avoid unnecessary Docker Hub
-    pulls (and the associated rate-limit pressure).  Falls back to pulling only
-    when the image is not available in the local daemon.
-    """
-    image_ref = f"{IMAGE_REPO}:{tag}"
-    inspect_cmd = f"{DOCKER_INSPECT_COMMAND} {image_ref}"
-
-    # Try inspecting the local image first (no registry pull required).
-    exit_code, inspect_output = run_command(inspect_cmd, False)
-
-    if exit_code != 0:
-        # Image not available locally – pull it.
-        pull_cmd = f"{DOCKER_PULL_COMMAND} {image_ref}"
-        pull_output = run_command(pull_cmd, False)[1]
-        if not pull_output:
-            return 0
-        exit_code, inspect_output = run_command(inspect_cmd, False)
-
-    if exit_code == 0:
-        content = f"# {image_ref}\n```json\n{inspect_output}\n```"
-        write_file(f"{DOCS_METADATA_DIR}/{tag}.md", content)
-
-    return 0
 
 
 def load_supported_versions():

--- a/bin/docker-build.py
+++ b/bin/docker-build.py
@@ -9,6 +9,7 @@ given OS distribution.
 
 import subprocess
 import common
+import docker_ops
 import argparse
 
 ARM64_ARCH = "arm64"
@@ -26,13 +27,15 @@ def main():
     arch = args.arch
 
     if arch == ARM64_ARCH:
-        arch = common.ARM64V8_ARCH
+        arch = docker_ops.ARM64V8_ARCH
 
     versions = common.load_supported_versions()
 
-    common.for_mainline_and_stable(common.build_image, versions, os_distro, arch)
+    common.for_mainline_and_stable(docker_ops.build_image, versions, os_distro, arch)
 
-    stdout = subprocess.check_output(common.DOCKER_IMAGES_COMMAND.split(), text=True)
+    stdout = subprocess.check_output(
+        docker_ops.DOCKER_IMAGES_COMMAND.split(), text=True
+    )
     print(stdout)
 
 

--- a/bin/docker-bundle.py
+++ b/bin/docker-bundle.py
@@ -9,6 +9,7 @@ versions for the specified operating system distribution.
 
 import argparse
 import common
+import docker_ops
 
 
 def main():
@@ -24,7 +25,7 @@ def main():
 
     versions = common.load_supported_versions()
 
-    common.for_mainline_and_stable(common.bundle_images, versions, os_distro)
+    common.for_mainline_and_stable(docker_ops.bundle_images, versions, os_distro)
 
 
 if __name__ == "__main__":

--- a/bin/docker-metadata.py
+++ b/bin/docker-metadata.py
@@ -10,6 +10,7 @@ markdown files with JSON metadata for both nginx mainline and stable versions.
 import sys
 import argparse
 import common
+import docker_ops
 
 
 def main():
@@ -27,12 +28,12 @@ def main():
     versions = common.load_supported_versions()
 
     tag = "%s-%s%s" % (versions["nginx_mainline"], os_distro, versions[os_distro])
-    exit_code = common.generate_metadata(tag)
+    exit_code = docker_ops.generate_metadata(tag)
     if exit_code > 0:
         sys.exit(1)
 
     tag = "%s-%s%s" % (versions["nginx_stable"], os_distro, versions[os_distro])
-    exit_code = common.generate_metadata(tag)
+    exit_code = docker_ops.generate_metadata(tag)
     if exit_code > 0:
         sys.exit(1)
 

--- a/bin/docker-push.py
+++ b/bin/docker-push.py
@@ -9,12 +9,13 @@ versions for the given OS distribution.
 
 import platform
 import common
+import docker_ops
 import argparse
 
 # Map platform.machine() values to Docker architecture names
 _MACHINE_TO_ARCH = {
-    "x86_64": common.AMD64_ARCH,
-    "aarch64": common.ARM64V8_ARCH,
+    "x86_64": docker_ops.AMD64_ARCH,
+    "aarch64": docker_ops.ARM64V8_ARCH,
 }
 
 
@@ -44,7 +45,7 @@ def main():
 
     versions = common.load_supported_versions()
 
-    common.for_mainline_and_stable(common.push_images, versions, os_distro, arch)
+    common.for_mainline_and_stable(docker_ops.push_images, versions, os_distro, arch)
 
 
 if __name__ == "__main__":

--- a/bin/docker_ops.py
+++ b/bin/docker_ops.py
@@ -1,0 +1,206 @@
+"""
+Docker build, push, manifest and inspect plumbing for nginx-lua images.
+
+Everything here shells out to `docker` (or `git`, for the build metadata that
+goes into the image). The tag vocabulary, the Dockerfile templating and the
+supported-version knowledge it works from live in common.py.
+"""
+
+import os
+import shlex
+import subprocess
+from datetime import datetime, timezone
+
+import common
+
+# Docker constants
+DOCKER_BUILD_COMMAND = "docker build"
+DOCKER_PUSH_COMMAND = "docker push"
+DOCKER_PULL_COMMAND = "docker pull"
+DOCKER_INSPECT_COMMAND = "docker image inspect"
+DOCKER_MANIFEST_CREATE = "docker manifest create"
+DOCKER_MANIFEST_PUSH = "docker manifest push"
+DOCKER_TAG_COMMAND = "docker tag"
+DOCKER_IMAGES_COMMAND = "docker images"
+
+# Git constants
+GIT_REV_PARSE_COMMAND = "git rev-parse --short HEAD"
+GIT_COMMIT_DATE_COMMAND = "git log -1 --format=%ct"
+
+# Architecture constants
+AMD64_ARCH = "amd64"
+ARM64V8_ARCH = "arm64v8"
+ARCHITECTURES = [AMD64_ARCH, ARM64V8_ARCH]
+
+# Build arguments
+ARCH_BUILD_ARG = "ARCH"
+BUILD_DATE_BUILD_ARG = "BUILD_DATE"
+VCS_REF_BUILD_ARG = "VCS_REF"
+
+# Date format
+BUILD_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
+
+# Documentation
+DOCS_METADATA_DIR = "docs/metadata"
+
+
+def run_command(command, print_stdout=True):
+    """Run a shell command and return exit code and output."""
+    print(f"Running: {command}")
+
+    process = subprocess.Popen(
+        shlex.split(command), shell=False, stdout=subprocess.PIPE
+    )
+
+    streamdata = process.communicate()[0]
+    output_lines = streamdata.decode("utf-8")
+    if print_stdout:
+        print(output_lines)
+
+    return [process.returncode, output_lines]
+
+
+def get_build_date():
+    """Derive BUILD_DATE from the current commit's timestamp rather than
+    wall-clock build time.
+
+    Rebuilding the exact same commit (e.g. a CI rerun of a single job,
+    whether same-day or not) then always produces the identical BUILD_DATE
+    build-arg, so the resulting image digest is identical too. A rerun
+    becomes a genuine no-op instead of silently pushing a new, unsigned
+    digest under an already-signed tag and orphaning the earlier signature.
+    """
+    commit_epoch = subprocess.check_output(
+        shlex.split(GIT_COMMIT_DATE_COMMAND), text=True
+    ).strip()
+    return datetime.fromtimestamp(int(commit_epoch), tz=timezone.utc).strftime(
+        BUILD_DATE_FORMAT
+    )
+
+
+def build_docker_image(vcs_ref, tags, dockerfile_path, arch):
+    """Build Docker image with given parameters."""
+    tag_params = " ".join([f"-t {tag}" for tag in tags])
+    build_date = get_build_date()
+
+    tarball_path = common.get_tarball_path(dockerfile_path)
+    os.makedirs(os.path.dirname(tarball_path), exist_ok=True)
+
+    build_command = f"""
+        {DOCKER_BUILD_COMMAND}
+        --progress=plain
+        --build-arg {ARCH_BUILD_ARG}="{arch}"
+        --build-arg {BUILD_DATE_BUILD_ARG}="{build_date}"
+        --build-arg {VCS_REF_BUILD_ARG}="{vcs_ref}"
+        {tag_params}
+        -f {dockerfile_path} {os.path.dirname(dockerfile_path)}
+    """
+
+    return run_command(build_command, True)[0]
+
+
+def build_image(nginx_version, os_distro, os_version, arch):
+    """Build Docker image for given configuration."""
+    dockerfile_path = common.get_dockerfile_path(nginx_version, os_distro, os_version)
+    tags = common.generate_tags(nginx_version, os_distro, os_version, arch)
+    vcs_ref = subprocess.check_output(
+        shlex.split(GIT_REV_PARSE_COMMAND), text=True
+    ).strip()
+
+    return build_docker_image(vcs_ref, tags, dockerfile_path, arch)
+
+
+def push_docker_image(tag):
+    """Push Docker image to registry with retry."""
+    cmd = f"{DOCKER_PUSH_COMMAND} {tag}"
+    exit_code = run_command(cmd, True)[0]
+
+    # Retry once if failed
+    if exit_code != 0:
+        exit_code = run_command(cmd, True)[0]
+
+    return exit_code
+
+
+def push_images(nginx_version, os_distro, os_version, arch=None):
+    """Push per-arch images to the registry.
+
+    Pushes images directly (without -unsigned suffix) since signing is
+    done on the multi-arch manifest list after bundling, not on per-arch
+    images.
+
+    If arch is provided, only images for that architecture are processed.
+    This is the expected behaviour in CI where each runner builds only
+    for its own architecture.
+    """
+    arches = [arch] if arch else ARCHITECTURES
+    for current_arch in arches:
+        tags = common.generate_tags(nginx_version, os_distro, os_version, current_arch)
+        for tag in tags:
+            exit_code = push_docker_image(tag)
+            if exit_code != 0:
+                print(f"FATAL: Failed to push image {tag}")
+                return exit_code
+
+    return 0
+
+
+def create_manifest(tag):
+    """Create and push multi-arch manifest."""
+    tag_amd64 = f"{tag}-{AMD64_ARCH}"
+    tag_arm64 = f"{tag}-{ARM64V8_ARCH}"
+
+    # Create manifest
+    create_cmd = f"""
+        {DOCKER_MANIFEST_CREATE}
+        {tag}
+        --amend {tag_amd64}
+        --amend {tag_arm64}
+    """
+    exit_code = run_command(create_cmd, True)[0]
+    if exit_code != 0:
+        return 1
+
+    # Push manifest
+    push_cmd = f"{DOCKER_MANIFEST_PUSH} {tag}"
+    return run_command(push_cmd, True)[0]
+
+
+def bundle_images(nginx_version, os_distro, os_version):
+    """Create multi-arch manifests for all tags."""
+    tags = common.generate_tags(nginx_version, os_distro, os_version, "")
+
+    for tag in tags:
+        exit_code = create_manifest(tag)
+        if exit_code != 0:
+            return 1
+
+    return 0
+
+
+def generate_metadata(tag):
+    """Generate metadata documentation for image tag.
+
+    Tries to inspect the image locally first to avoid unnecessary Docker Hub
+    pulls (and the associated rate-limit pressure).  Falls back to pulling only
+    when the image is not available in the local daemon.
+    """
+    image_ref = f"{common.IMAGE_REPO}:{tag}"
+    inspect_cmd = f"{DOCKER_INSPECT_COMMAND} {image_ref}"
+
+    # Try inspecting the local image first (no registry pull required).
+    exit_code, inspect_output = run_command(inspect_cmd, False)
+
+    if exit_code != 0:
+        # Image not available locally – pull it.
+        pull_cmd = f"{DOCKER_PULL_COMMAND} {image_ref}"
+        pull_output = run_command(pull_cmd, False)[1]
+        if not pull_output:
+            return 0
+        exit_code, inspect_output = run_command(inspect_cmd, False)
+
+    if exit_code == 0:
+        content = f"# {image_ref}\n```json\n{inspect_output}\n```"
+        common.write_file(f"{DOCS_METADATA_DIR}/{tag}.md", content)
+
+    return 0

--- a/bin/generate_tags.py
+++ b/bin/generate_tags.py
@@ -24,6 +24,45 @@ LATEST_TAG = "latest"
 GITHUB_BASE_URL = "https://github.com/fabiocicerchia/nginx-lua/blob/main/"
 
 
+def tag_names(dockerfile_path):
+    """Every tag name the image built from one Dockerfile answers to.
+
+    The order is the insertion order of main()'s tag -> Dockerfile map, and
+    the sort that renders it is stable, so it survives into the output.
+    """
+    match = re.search(DOCKERFILE_REGEX, dockerfile_path)
+
+    nginx_ver, os_distro, os_version, compat = match.group(1, 2, 3, 4)
+    major, minor, patch = re.split(r"\.", nginx_ver)
+    suffix = ""
+    if compat is not None:
+        suffix = COMPAT_SUFFIX
+
+    is_alpine = os_distro == ALPINE_DISTRO
+    # amazonlinux 2018 predates the unversioned distro tags and never claims them
+    claims_distro_tag = not (
+        os_distro == AMAZONLINUX_DISTRO
+        and os_version.startswith(AMAZONLINUX_2018_PREFIX)
+    )
+
+    names = [
+        f"{major}.{minor}.{patch}-{os_distro}{os_version}{suffix}",
+        f"{major}.{minor}.{patch}-{os_distro}{suffix}",
+    ]
+    if is_alpine:
+        names.append(f"{major}.{minor}.{patch}-{suffix}")
+        names.append(f"{major}.{minor}{suffix}")
+    names.append(f"{major}-{os_distro}{os_version}{suffix}")
+    names.append(f"{os_distro}{suffix}")
+    if claims_distro_tag:
+        names.append(f"{major}-{os_distro}{suffix}")
+    if is_alpine:
+        names.append(f"{major}{suffix}")
+        names.append(f"{LATEST_TAG}{suffix}")
+
+    return names
+
+
 def main():
     files = sorted(
         str(path) for path in Path("nginx").rglob(DOCKERFILE_PATTERN) if path.is_file()
@@ -33,34 +72,8 @@ def main():
 
     tags = {}
     for file in files:
-        match = re.search(DOCKERFILE_REGEX, file)
-
-        nginx_ver, os_distro, os_version, compat = match.group(1, 2, 3, 4)
-        major, minor, patch = re.split(r"\.", nginx_ver)
-        suffix = ""
-        if compat is not None:
-            suffix = COMPAT_SUFFIX
-
-        is_alpine = os_distro == ALPINE_DISTRO
-        # amazonlinux 2018 predates the unversioned distro tags and never claims them
-        claims_distro_tag = not (
-            os_distro == AMAZONLINUX_DISTRO
-            and os_version.startswith(AMAZONLINUX_2018_PREFIX)
-        )
-
-        tags[f"{major}.{minor}.{patch}-{os_distro}{os_version}{suffix}"] = file
-        tags[f"{major}.{minor}.{patch}-{os_distro}{suffix}"] = file
-        if is_alpine:
-            tags[f"{major}.{minor}.{patch}-{suffix}"] = file
-        if is_alpine:
-            tags[f"{major}.{minor}{suffix}"] = file
-        tags[f"{major}-{os_distro}{os_version}{suffix}"] = file
-        tags[f"{os_distro}{suffix}"] = file
-        if claims_distro_tag:
-            tags[f"{major}-{os_distro}{suffix}"] = file
-        if is_alpine:
-            tags[f"{major}{suffix}"] = file
-            tags[f"{LATEST_TAG}{suffix}"] = file
+        for tag in tag_names(file):
+            tags[tag] = file
 
     dockerfiles = defaultdict(list)
     unsupported = files

--- a/bin/generate_tags.py
+++ b/bin/generate_tags.py
@@ -33,54 +33,53 @@ def main():
 
     tags = {}
     for file in files:
-        pieces = re.search(DOCKERFILE_REGEX, file)
+        match = re.search(DOCKERFILE_REGEX, file)
 
-        nginx_ver, os_distro, osVer, compat = pieces.group(1, 2, 3, 4)
-        nginx_ver_pieces = re.split(r"\.", nginx_ver)
-        nginx_ver_major, nginx_ver_minor, nginx_ver_patch = nginx_ver_pieces
+        nginx_ver, os_distro, os_version, compat = match.group(1, 2, 3, 4)
+        major, minor, patch = re.split(r"\.", nginx_ver)
         suffix = ""
         if compat is not None:
             suffix = COMPAT_SUFFIX
 
-        tags[
-            f"{nginx_ver_major}.{nginx_ver_minor}.{nginx_ver_patch}-{os_distro}{osVer}{suffix}"
-        ] = file
-        tags[
-            f"{nginx_ver_major}.{nginx_ver_minor}.{nginx_ver_patch}-{os_distro}{suffix}"
-        ] = file
-        if os_distro == ALPINE_DISTRO:
-            tags[f"{nginx_ver_major}.{nginx_ver_minor}.{nginx_ver_patch}-{suffix}"] = (
-                file
-            )
-        if os_distro == ALPINE_DISTRO:
-            tags[f"{nginx_ver_major}.{nginx_ver_minor}{suffix}"] = file
-        tags[f"{nginx_ver_major}-{os_distro}{osVer}{suffix}"] = file
-        tags[f"{os_distro}{suffix}"] = file
-        if not (
+        is_alpine = os_distro == ALPINE_DISTRO
+        # amazonlinux 2018 predates the unversioned distro tags and never claims them
+        claims_distro_tag = not (
             os_distro == AMAZONLINUX_DISTRO
-            and osVer.startswith(AMAZONLINUX_2018_PREFIX)
-        ):
-            tags[f"{nginx_ver_major}-{os_distro}{suffix}"] = file
-        if os_distro == ALPINE_DISTRO:
-            tags[f"{nginx_ver_major}{suffix}"] = file
+            and os_version.startswith(AMAZONLINUX_2018_PREFIX)
+        )
+
+        tags[f"{major}.{minor}.{patch}-{os_distro}{os_version}{suffix}"] = file
+        tags[f"{major}.{minor}.{patch}-{os_distro}{suffix}"] = file
+        if is_alpine:
+            tags[f"{major}.{minor}.{patch}-{suffix}"] = file
+        if is_alpine:
+            tags[f"{major}.{minor}{suffix}"] = file
+        tags[f"{major}-{os_distro}{os_version}{suffix}"] = file
+        tags[f"{os_distro}{suffix}"] = file
+        if claims_distro_tag:
+            tags[f"{major}-{os_distro}{suffix}"] = file
+        if is_alpine:
+            tags[f"{major}{suffix}"] = file
             tags[f"{LATEST_TAG}{suffix}"] = file
 
     dockerfiles = defaultdict(list)
-    reversed_list = files
+    unsupported = files
     for tag in tags:
         dockerfiles[tags[tag]].append(tag)
     for dockerfile in dockerfiles:
-        dockerfiles[dockerfile] = sorted(dockerfiles[dockerfile], key=operator.itemgetter(0))
+        dockerfiles[dockerfile] = sorted(
+            dockerfiles[dockerfile], key=operator.itemgetter(0)
+        )
 
     print("# Tags\n")
     print("## Supported Tags\n")
     for file in supported:
-        reversed_list.remove(file)
+        unsupported.remove(file)
         print(f"- [`{', '.join(dockerfiles[file])}`]({GITHUB_BASE_URL}{file})")
 
     print("\n## Unsupported Tags\n")
-    reversed_list = list(reversed_list)[::-1]
-    for file in reversed_list:
+    unsupported = list(unsupported)[::-1]
+    for file in unsupported:
         print(f"- [`{', '.join(dockerfiles[file])}`]({GITHUB_BASE_URL}{file})")
 
 

--- a/bin/generate_tags.py
+++ b/bin/generate_tags.py
@@ -52,16 +52,6 @@ def main():
             tags[f"{nginx_ver_major}.{nginx_ver_minor}.{nginx_ver_patch}-{suffix}"] = (
                 file
             )
-        tags[
-            f"{nginx_ver_major}.{nginx_ver_minor}.{nginx_ver_patch}-{os_distro}{osVer}{suffix}"
-        ] = file
-        if not (
-            os_distro == AMAZONLINUX_DISTRO
-            and osVer.startswith(AMAZONLINUX_2018_PREFIX)
-        ):
-            tags[
-                f"{nginx_ver_major}.{nginx_ver_minor}.{nginx_ver_patch}-{os_distro}{suffix}"
-            ] = file
         if os_distro == ALPINE_DISTRO:
             tags[f"{nginx_ver_major}.{nginx_ver_minor}{suffix}"] = file
         tags[f"{nginx_ver_major}-{os_distro}{osVer}{suffix}"] = file


### PR DESCRIPTION
**elevate-code — `nginx-lua` · branch `elevate-code/20260902` · 4 commits · Python driver scripts around a Docker/nginx/Lua image matrix**
Scope: whole tree, changes confined to `bin/*.py` · Patterns: all evaluated, VERSION/CONST/NESTED/TYPES/PATTERNS/DATA/LOG/EXIT/GREEN/HARDEN/DOCS produced no commit · Genome source: `references/genome.md` (fallback — no CLAUDE.md or GENOME.md in this repo)

This repo has outside human contributors, so the diff is deliberately small: 4 commits, 6 files, +221/−203, all under `bin/`. 443 gradebook findings were **not** cleared and were never going to be — see *Skipped* for the arithmetic on why 416 of them are out of reach by construction.

**Repo facts** (filled in step 1, before any change)
- Dependency policy: deps allowed — `bin/requirements.txt` pins `requests` + its transitive set. No packaging file, no `pyproject.toml`, no `requires-python`. Scripts are run directly by the Makefile (`./bin/docker-build.py`), never installed.
- Front door: `make help` (79 targets: build-*, test-*, push-*, packages, auto-update, generate-*, sign/verify-image). `make help` is **not** in the baseline — it depends on a `git fetch`, so it is neither offline nor deterministic.
- Version wiring: none in source. Image versions live in `supported_versions` and `src/.env.dist`, both generated. No release-please config.
- Consumers of the moved module: `bin/docker-build.py`, `bin/docker-push.py`, `bin/docker-bundle.py`, `bin/docker-metadata.py` — all four updated in the same commit. No doc, workflow or Makefile names any moved function (proof below).
- Baseline covered: **no test suite exists** (`grep -qE '^test:' Makefile` fails; `make test-all` builds and runs Docker images). 12 smoke commands, all offline and deterministic: the two tag generators end-to-end over all 808 Dockerfiles, the fossa-deps generator checked for idempotency against `git diff --quiet`, `--help` on the four argparse CLIs, three pure-function probes into `common`, `bash -n` on the three largest shell scripts, and a signature freeze over the nine functions the FILE commit moves.
- Design constraints the repo states about itself: `nginx/**` (806 Dockerfiles + their `tpl/` trees) is **generated** by `bin/generate-dockerfiles.py` from `src/Dockerfile.<distro>`; `src/*.sh` are **vendored upstream** nginx entrypoint scripts, re-downloaded by `make pull-nginx-entrypoints` and checksummed in `src/checksums.sha256`. Neither is editable by hand.

**What the baseline could not reach** (step 3 — mandatory)

| Pattern | Status | Why | Decision |
|---|---|---|---|
| DUP / NAME / FUNC — `bin/generate_tags.py` | verifiable | smoke 01 `python3 bin/generate_tags.py` renders every tag for all 808 Dockerfiles; the recorded stdout is diffed byte for byte | done |
| FILE — tag/version half of `common.py` | verifiable | smoke 02, 08, 09, 10 call `generate_tags`, `get_supported_versions`, `get_tarball_path`, `get_version_parts`, `print_tags` directly | done |
| FILE — the nine docker/registry functions | unverifiable-here | every one shells out to `docker` or Docker Hub: `build_image` needs a daemon and a 25k-line Dockerfile build, `push_images`/`create_manifest` need registry credentials, `generate_metadata` needs a pushed image | **proceeding blind** — see below |
| DUP / FUNC — `bin/package-base-nginx.sh` (`main`, complexity 11), `bin/package-test-base.sh`, `bin/generate-changelog.sh` | unverifiable-here | the baseline can only `bash -n` them. Each needs a built image, a package manager inside a container, or a GitHub token: `bash bin/package-base-nginx.sh alpine 1.31.4 amd64` → `docker: command … no such image` | **deferred** |
| NAME / FUNC — `bin/generate-deps-env.py`, `bin/generate-supported-versions.py`, `bin/cleanup-docker-images.py` | unverifiable-here | all three are GitHub-API / Docker-Hub-API clients with no offline path and no fixtures; `cleanup-docker-images.py` deletes registry tags | **deferred** |
| HARDEN | n/a — rejected on inspection, not deferred | see *Rejected findings* | no commit |
| GREEN | no occurrences | greenlint finds nothing in `bin/` or `src/` | no commit |

- **FILE — shipped unverified (move only).** Nine functions (`run_command`, `get_build_date`, `build_docker_image`, `build_image`, `push_docker_image`, `push_images`, `create_manifest`, `bundle_images`, `generate_metadata`) moved from `bin/common.py` to a new `bin/docker_ops.py`. The baseline cannot execute any of them: they need a Docker daemon, a 25k-line image build and Docker Hub credentials. What stands in for the check: (a) an AST diff proving the move is a **pure relocation** — 4 of the 9 bodies are byte-identical to `origin/main` and the other 5 differ only by the `common.` prefix on cross-module references (`common.get_tarball_path`, `common.generate_tags`, `common.get_dockerfile_path`, `common.IMAGE_REPO`, `common.write_file`), with the full diff pasted under *Dismissals*; (b) all 13 functions that stayed in `common.py` are byte-identical; (c) smoke line 12 resolves all nine names through whichever module now owns them and freezes their signatures, and it is in the recorded baseline, so a dropped or re-signatured function fails `baseline.sh check`; (d) smoke 04–07 prove the four consumer CLIs still import cleanly. What would verify it properly: `make build-amd64-alpine && make docker-test-amd64-alpine` on a host with a Docker daemon and ~30 minutes. Anyone re-running this sweep on such a host should re-check this first.

**Scorecard** (from `tools.sh compare`, unedited)
```
gradebook-code       87.1 A  findings 443  →  87.0 A  findings 440
gradebook-tests      37.1 F  findings 8  →  37.1 F  findings 8
gandalf              fail 82 (41/41 gates ran)  →  fail 82 (41/41 gates ran)
greenlint            72 finding(s) (72 medium)  →  72 finding(s) (72 medium)
depwatch             not run (no manifest at the repo root)  →  not run (no manifest at the repo root)
dockerfile-hardener  808 of 808 Dockerfile(s) not yet hardened  →  808 of 808 Dockerfile(s) not yet hardened
automap              0 components, 0 edges, 0 cycles, 0 violations; check exit 2 (no committed map?)  →  0 components, 0 edges, 0 cycles, 0 violations; check exit 2 (no committed map?)
readthrough          not run (ANTHROPIC_API_KEY unset)  →  not run (ANTHROPIC_API_KEY unset)
```

Per-dimension (`scorecard.py --dimensions`):
```
kiss       Simplicity (KISS)              0.82 → 0.82  (+0.00)
hotspots   Hotspots (churn x complexity)  1.00 → 1.00
dry        Duplication (DRY)              0.30 → 0.30  (+0.00)
srp        Single responsibility          1.00 → 1.00  (+0.00)
ocp        Open/closed                    1.00 → 1.00  (+0.00)
dip        Dependency inversion           1.00 → 1.00  (+0.00)
coupling   Coupling (GRASP)               0.99 → 0.98
demeter    Law of Demeter                 0.98 → 0.98  (+0.00)
yagni      Speculative generality (YAGNI) 0.98 → 0.98  (+0.00)
naming     Naming & intent                0.97 → 0.97  (+0.00)

no dimension dropped by more than 0.15; no new high-severity finding kind
```

Finding kinds, before → after:
```
high   complex-function   2 → 1     (bin/generate_tags.py:27 gone)
high   god-file           1 → 0     (bin/common.py gone)
high   hotspot           10 → 10
low    long-function      6 → 5
medium deep-nesting     403 → 403
medium duplicate-block   20 → 20
medium mixed-concerns      1 → 1
```
The only two entries in NEW are `deep-nesting` and `long-function` on `bin/common.py` moving from line 110 to line 62 — the same finding on the same untouched function (`generate_tags`), which simply sits higher in the file now that 194 lines above it moved out.

Gate check: gradebook-code composite dropped 0.1 — see *Regressions*, it is entirely `coupling` · gandalf **stayed exactly as red as it was** (82, `fail`, same two gates: `yamllint` 1 error, `tests` "no tests ran"; 41/41 gates ran both times, no gate changed outcome) · automap: 0 cycles, 0 violations before and after, `check` exit 2 both times because the repo commits no map.

**Where the numbers came from** (mandatory)

| Tool | Total delta | Code | Config | Environment |
|---|---|---|---|---|
| gradebook-code | 87.1 → 87.0 (−0.1) | −0.1 | 0 | 0 |
| gradebook-tests | 37.1 → 37.1 (0) | 0 | 0 | 0 |
| gandalf | 82 fail → 82 fail (0) | 0 | 0 | 0 |
| greenlint | 72 → 72 (0) | 0 | 0 | 0 |
| dockerfile-hardener | 808/808 → 808/808 (0) | 0 | 0 | 0 |

**Code-only delta: −0.1 on the gradebook-code composite, with the two structural high findings I could reach removed (`god-file` 1 → 0, `complex-function` 2 → 1) and `hot_complexity` over the most-changed files down 5.5 → 5.0.** No config file was touched and no environment changed, so the code column is the whole story in both directions. The composite fell despite the finding count falling, and that is honest arithmetic, not noise — the split cost more on `coupling` than it gained on `srp` and `kiss` combined.

**Regressions** (mandatory)

- **REGRESSION — Coupling (GRASP): 0.988 → 0.982 (−0.006), detail `0.2 internal imports per module` → `0.4`.** Cause: `refactor(FILE)` — one new module (37 → 38) and five new internal import edges (`fan_out_total` 9 → 14: `docker_ops → common`, plus the four CLIs now importing `docker_ops` alongside `common`). Justification: **it stands.** This is the mechanical price of splitting a god file into two files that must reference each other, and it bought `god_files` 1 → 0 with `srp` 0.9969 → 0.9986. Trading a *high* `god-file` for +0.2 internal imports per module is the trade the size budget asks for; refusing it would mean leaving the repo's most-changed file (33 commits) at 22 functions and 5 concerns. It is also the entire cause of the −0.1 composite: every other dimension held or rose.
- **NEW HIGH — none.** `hotspot` stayed at 10 and no new kind appeared at high severity.
- Dimensions whose gain came from a changed denominator (**not counted as improvements**): `naming` 0.9742 → 0.9742 (the same 17 vague names over 4505 → 4506 functions), `yagni`, `demeter`, `dip`, `ocp`, `dry` — all six moved in the 4th–5th decimal only because the tree grew by 12 lines and 1 function. Their numerators did not move at all. Do not read any of them as a gain.
- `kiss` 0.8174 → 0.8184 **is** real: the numerator moved — `complex_functions` 2 → 1, `long_functions` 6 → 5.
- `hotspots` held at 1.00; the underlying detail improved (`the 49 most-changed files average 5.5 complexity against 6.9` → `average 5.0 against 6.9`, 0.8x → 0.7x). The codebase average was unchanged at 6.9, so no threshold-artefact hotspots appeared on untouched files.

**Config changes**
- none. No linter, gandalf, greenlint or CI config was added, relaxed or edited. `.github/workflows/`, `.editorconfig`, `SECURITY.md` untouched.

**Commits**

| # | Commit | Occurrences | Notes |
|---|---|---|---|
| 1 | `refactor(DUP): drop two dead tag assignments in generate_tags` | 2 | both keys already written a few lines above with the same value; the amazonlinux-2018 guard on the second guarded nothing |
| 2 | `refactor(NAME): say what the tag variables are in generate_tags` | 6 | `osVer` → `os_version`, `pieces` → `match`, `nginx_ver_major/minor/patch` → `major/minor/patch`, `reversed_list` → `unsupported`, two inline distro tests bound to `is_alpine` / `claims_distro_tag` |
| 3 | `refactor(FUNC): lift the tag vocabulary out of generate_tags main` | 1 | `main` 61 lines / complexity 16 → 25 lines / complexity 8; new `tag_names()` |
| 4 | `refactor(FILE): move docker build/push plumbing to bin/docker_ops.py` | 1 god-file + 1 mixed-concerns | `common.py` 350 → 256 lines, 22 → 13 functions, complexity 56 → 34; 4 call sites updated |
| — | VERSION, CONST, NESTED, TYPES, PATTERNS, DATA, LOG, EXIT, GREEN, HARDEN, DOCS | 0 reachable / rejected | no commit |

**Skipped** (flagged by a threshold or a tool, left alone on purpose)

- **`nginx/**` — 399 of 403 `deep-nesting` and 17 of 20 `duplicate-block` findings, plus 71 of 72 greenlint findings and 806 of 808 hardener diffs — accepted-with-reason: the whole directory is generated.** `bin/generate-dockerfiles.py` writes `nginx/<ver>/<distro>/<osver>/Dockerfile` and copies `src/*.sh` into each `tpl/`, and `Makefile:313 generate-dockerfiles` regenerates it. Hand-editing it would be reverted by the next `make auto-update`. Expected, not a regression, not to be chased next sweep. **That is 416 of the 443 findings.**
- **`src/10-listen-on-ipv6-by-default.sh`, `src/20-envsubst-on-templates.sh`, `src/30-tune-worker-processes.sh`, `src/docker-entrypoint.sh`, `src/15-local-resolvers.envsh` — accepted-with-reason: vendored upstream.** `Makefile:342-346 pull-nginx-entrypoints` re-downloads them from nginx's own repo through `bin/download-and-verify.sh`, and `src/checksums.sha256` pins their hashes. Editing them breaks the checksum gate.
- `bin/package-base-nginx.sh:62` — `main` complexity 11 (limit 10), 43 lines — left. The only *high* finding left in hand-written code, and the baseline cannot execute a single line of it (needs a built image + a container package manager). Deferring per step 3 rather than proceeding blind on a shell script that installs system packages.
- `bin/package-base-nginx.sh:21,27` and `bin/package-test-base.sh:34` — three 8-line `duplicate-block`s shared with `bin/generate-changelog.sh` — left. Same reachability wall, and `bin/lib-retry.sh` already exists as the extraction point, so this is a well-shaped follow-up for a host that can run the scripts.
- `bin/generate-deps-env.py:1` — `mixed-concerns` (crypto, filesystem, http, ui) and `main` 64 lines — left. Every path is a live GitHub-API call with no fixture; splitting it blind is exactly the failure step 3 exists to prevent.
- `bin/cleanup-docker-images.py:77` — `main` nesting 4 (limit 3.5) — left; it deletes Docker Hub tags, unreachable offline.
- `bin/common.py:62` — `generate_tags` 41 lines (limit 40), nesting 4 — left. One line over, and it is the function that decides which image answers to `latest`; the comment above it explains a signature-orphaning hazard. Splitting it to save one line is the size-budget trap.
- `bin/deps_manifest.py` (229 lines, 30 dependency dicts) — the obvious DATA candidate, **not** converted to TOML. Its own docstring already declares it "Single source of truth for third-party nginx/Lua module dependencies", it is imported by exactly two scripts, and a TOML file plus a loader would add a unit without removing a reason to change. `tomllib` *is* available (no `requires-python` floor; the scripts run on whatever python3 CI provides, and gandalf's `build` gate compiles all 13/14 files) — so this is a taste call, not a blocked one.
- `bin/deps_manifest.py` and `bin/generate-deps-env.py` fail `black --check` (they are 2 of the 3 files gandalf's `format` gate names). Not fixed: reformatting files this sweep does not otherwise touch is drive-by churn in a repo with outside contributors. `bin/generate_tags.py`, the third, is now black-clean as a side effect of commits 2 and 3.
- DOCS / `automap map` — no `ARCHITECTURE.md` or `.automap.baseline.json` committed. automap reports 0 components and 0 edges on this tree (it is 99% generated Dockerfiles and shell), so the map would be empty, and it would add two generated files outside contributors must keep in sync.

**Judgment calls**

- Restricted the whole sweep to `bin/*.py`. `nginx/**` is generated, `src/*.sh` is vendored and checksummed, and every `bin/*.sh` is unreachable from an offline baseline. That is 2537 of 2550 files legitimately out of scope, and it is why 4 commits is the right size here rather than a failure of ambition.
- Did **not** extract a `print_section()` helper in commit 3, though the two bullet-printing lines in `main` are identical. Per the anti-pattern rule they are one line each with no drift hazard, and extracting would have changed the interleaving of output and the `unsupported.remove()` `ValueError` on the "a supported Dockerfile is missing" path. Left inline; `main` is complexity 8 without it.
- Kept `unsupported.remove(file)` rather than the tidier `[f for f in files if f not in supported]`. `remove` raises `ValueError` when a supported Dockerfile is absent from disk — i.e. when `make generate-dockerfiles` has not been run — and the list comprehension would swallow that silently. A fail-loud path stays fail-loud.
- Merged the two adjacent `if is_alpine:` blocks in commit 3 but kept every other statement's order. Insertion order into the `tags` dict is load-bearing: the render sorts with `key=operator.itemgetter(0)` (first character only), Python's sort is stable, so ties fall back to insertion order and into the output. `tag_names()`'s docstring says so.
- Size budget: `bin/common.py` 350 → 256 non-blank-ish lines (−27%), 22 → 13 functions; `bin/docker_ops.py` is new at 206 lines / 9 functions. The budget's ceiling is on *growth*; both files shrank or split along a concern boundary that already existed (nothing in `docker_ops.py` is called by anything except the four docker CLIs). No file grew.
- Left `DOCKER_TAG_COMMAND` in place (moved to `docker_ops.py` with its siblings) even though nothing references it. Deleting it is a dead-code claim, not a FILE claim, and it does not belong in a move commit.
- Did not touch `docker-compose.test.yml` for greenlint GL034 (missing resource limits). Setting `mem_limit`/`cpus` on the test harness changes how the tests run — a behaviour change on a path the baseline cannot execute.

**Dismissals, with proof**

- "No doc, workflow or Makefile names any moved function" —
  ```
  $ git grep -n "build_docker_image\|push_docker_image\|create_manifest\|bundle_images\|generate_metadata\|get_build_date\|run_command" -- '*.md' '*.yml' '*.yaml' 'Makefile' ':!docs/metadata'
  (no output)
  ```
- "Constants moved to `docker_ops.py` are used nowhere else" —
  ```
  $ grep -rn "DOCKER_TAG_COMMAND\|DOCS_METADATA_DIR\|DIST_DIR\|MULTIARCH_PREFIX\|get_tarball_path\|LATEST_TAG" bin/ Makefile .github/ | grep -v "^bin/common.py"
  bin/generate_tags.py:23:LATEST_TAG = "latest"
  bin/generate_tags.py:61:        names.append(f"{LATEST_TAG}{suffix}")
  ```
  (`generate_tags.py` defines its own `LATEST_TAG`; `get_tarball_path` therefore stayed in `common.py`, where the smoke baseline calls it.)
- "The FILE commit is a pure relocation" — AST-level comparison of every function against `origin/main:bin/common.py`:
  ```
  $ python3 - <<'EOF'   # full script in the session transcript
  ... compares ast.FunctionDef source ranges, old vs new ...
  EOF
  moved byte-identical: 4/9, changed: 5
  stayed byte-identical: 13 / 13
  ```
  and the five that changed, in full — every hunk is a `common.` prefix and nothing else:
  ```
  build_docker_image: -    tarball_path = get_tarball_path(dockerfile_path)
                      +    tarball_path = common.get_tarball_path(dockerfile_path)
  build_image:        -    dockerfile_path = get_dockerfile_path(...)   +  common.get_dockerfile_path(...)
                      -    tags = generate_tags(...)                    +  common.generate_tags(...)
  push_images:        -        tags = generate_tags(...)                +  common.generate_tags(...)
  bundle_images:      -    tags = generate_tags(...)                    +  common.generate_tags(...)
  generate_metadata:  -    image_ref = f"{IMAGE_REPO}:{tag}"            +  f"{common.IMAGE_REPO}:{tag}"
                      -        write_file(f"{DOCS_METADATA_DIR}/...")   +  common.write_file(...)
  ```
- "The two removed tag assignments were dead" — both keys are written earlier in the *same* loop iteration with the same value, so re-assigning them changes neither the value nor the dict's insertion position. Proved end to end by the baseline: `python3 bin/generate_tags.py` over all 808 Dockerfiles is byte-identical before and after.
- "greenlint finds nothing in hand-written code" —
  ```
  $ python3 -c "... collections.Counter((rule, file.split('/')[0]) ..."
  59 ('GL006', 'nginx')
  12 ('GL015', 'nginx')
  1  ('GL034', 'docker-compose.test.yml')
  ```
  0 findings under `bin/` or `src/`. GREEN gets no commit.
- "`nginx/**` is generated" — `bin/generate-dockerfiles.py:19-27` calls `common.setup_dockerfile()` for every supported distro, which `shutil.copyfile`s `src/Dockerfile.<distro>` to `nginx/<ver>/<distro>/<osver>/Dockerfile` and `src/*.sh` into its `tpl/`; `Makefile:313` wires it to `make generate-dockerfiles`, itself a prerequisite of `make auto-update`.

**What a user of the tool will notice**

- Nothing. No CLI flag, no argparse help text, no stdout format, no exit code and no nginx directive changed. The four `--help` outputs and both tag-document generators are byte-identical in the recorded baseline.
- LOG: no change — this repo has no `print(..., file=sys.stderr)` in the files touched, and no logger was introduced.
- EXIT: no change — no exit code was touched anywhere.
- One internal change a *contributor* will notice: `import docker_ops` alongside `import common` in the four `bin/docker-*.py` scripts, and `common.build_image` → `docker_ops.build_image` (same for `push_images`, `bundle_images`, `generate_metadata`, `AMD64_ARCH`, `ARM64V8_ARCH`, `DOCKER_IMAGES_COMMAND`).

**Checks written by the sweep**

- None needed — no commit changes what a user sees, so none of them is an EXIT/LOG/control-flow commit requiring a new test. The sweep did not add a test suite to a repo that has none; that is the follow-up below.
- The 12-line `smoke.txt` **is** the check, and it was falsified before it was trusted: replacing `tags[f"{os_distro}{suffix}"] = file` with `pass` in `bin/generate_tags.py` produced
  ```
  DRIFT  01  out differs for: python3 bin/generate_tags.py
  ```
  then the file was restored and `baseline.sh check` went back to `identical across 12 command(s)`. Smoke line 12 (the signature freeze) was written and run against `origin/main` before the FILE commit so that both phases compare like for like.

**Rejected findings** (mandatory)

- **dockerfile-hardener `[pin-base]` on `src/Dockerfile.alpine:387,431` — `FROM base` → `FROM base:latest` — rejected: the premise is wrong.** `base` is not an image, it is a build stage declared in the same file at `src/Dockerfile.alpine:17` (`FROM ${ARCH}/$DISTRO:$DISTRO_VER AS base`). Tagging a stage name would make the build pull a nonexistent `base:latest` from Docker Hub. Applying this would break all 808 Dockerfiles.
- **dockerfile-hardener `[non-root]` — insert `USER 10001` before `ENTRYPOINT` — rejected: it would break the image and change a security decision.** The image runs nginx's master as root to bind `EXPOSE 80 443` (`src/Dockerfile.alpine:642`) and drops privileges the correct way, in `src/nginx.conf:1` (`user  nginx;`). Swapping a privilege-drop the daemon performs for a blanket `USER 10001` is a control being rewritten by a tool that cannot see the config file. Rejected on sight per the "security decisions never move" rule.
- Consequently **no HARDEN commit**, and the hardener row correctly reads 808/808 "not yet hardened" both before and after. That number is a measurement of a tool that is wrong about this repo, not of unhardened images.
- readthrough: no findings to accept or reject — it did not run.

**Left for a human**

- greenlint: 72 medium findings, 71 of them in generated `nginx/**` (`GL006` ×59, `GL015` ×12) — fixable only by changing `src/Dockerfile.<distro>` and regenerating, i.e. an 806-file diff, which is its own PR. Plus `docker-compose.test.yml:2 [GL034/medium] docker-compose service(s) without resource limits` — "set `deploy.resources.limits` or `mem_limit`/`cpus`"; not fixed because it changes how the test harness runs.
- depwatch: **ran, by hand** — `tools.sh` skips it here because it only looks for a manifest at the repo *root* and this repo's is `bin/requirements.txt`. Result: 0.33 libyears across 5 deps; quadrants `replace 0 · upgrade 0 · watch 0 · healthy 5`. The **`replace` quadrant is empty.** Only `urllib3` has any drift (2.6.3 → 2.7.0, 0.33 libyears, viability 1.00). Nothing to do; no dependency was added, removed or bumped in this branch.
- dockerfile-hardener: image **not built** — both of its suggestions are rejected above as build-breaking, so there was nothing to verify with a `docker build`. Docker is available on this host; a HARDEN commit simply had no valid content. The `USER`/`FROM` TODO lines it wants are at `src/Dockerfile.alpine:387,431,646` (and the same three points in the other five distro templates).
- readthrough: **not run** — `ANTHROPIC_API_KEY` unset (tools.md case 5). The free estimate was recorded at `/tmp/elevate-code-nginx-lua/{before,after}/readthrough/estimate.txt`. This is a dark referee, not a pass: no LLM read this diff. Fix: `export ANTHROPIC_API_KEY=… && tools.sh before/after`.
- Tools not run: readthrough (above); depwatch via `tools.sh` (root-manifest glob — run by hand, result above). Everything else ran: gradebook-code, gradebook-tests, gandalf (41/41 gates), greenlint, dockerfile-hardener (808 files), automap.
- gandalf's own dark gates, unchanged by this branch and worth knowing about: `codeql`, `kics`, `cppcheck`, `atheris`, `scorecard`, `ci_act` skipped for missing tooling, and all four LLM judges (`pr_code_summary`, `quality_gate_review`, `ruthless_refactor`, `security_assessment`) returned HTTP 401. `quality_gate_review` is the one marked blocking.
- Repo clean after the sweep: `git status --porcelain` empty. Every tool wrote under `$ELEVATE_DIR`; automap ran in a throwaway worktree.

**Follow-ups** (not done in this sweep, on purpose)

- **No test suite exists.** gandalf's `tests` gate has been failing with "no tests ran" since before this branch, and gradebook-tests sits at 37.1 F. `bin/common.py`'s `generate_tags()` decides which built image claims `latest` and the bare distro tags — its comment at `bin/common.py:116-123` describes a real incident where an ambiguous tag orphaned a cosign signature. That function is pure, takes four strings and returns a sorted list: a dozen `assert`s in a `bin/test_tags.py` would be the highest-value test in the repo and would put a real gate behind the next sweep. Deliberately not added here — this sweep does not build the suite the repo never had.
- The three shell `duplicate-block`s between `bin/package-base-nginx.sh`, `bin/package-test-base.sh` and `bin/generate-changelog.sh` want extracting into the existing `bin/lib-retry.sh`, on a host that can run them.
- `bin/generate-deps-env.py` (`mixed-concerns`: crypto, filesystem, http, ui; `main` 64 lines) is the largest remaining structural finding in hand-written code. It needs fixtures or a recorded-response harness before anyone should touch it.
- `docs/DEV.md:138-139` tells contributors to edit `bin/_common.sh`, a file that does not exist (`ls bin/_common.sh` → no such file). Stale doc, unrelated to this branch.

Next: `pr-review` on branch `elevate-code/20260902`.
